### PR TITLE
Drop pgp.mit.edu keyserver.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV \
 	LANG=C.UTF-8 \
 	LANGUAGE=C.UTF-8 \
 	DEBIAN_FRONTEND=noninteractive \
-	GPG_SERVERS="ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80 pgp.mit.edu"
+	GPG_SERVERS="ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80"
 
 # add runtime user
 RUN \


### PR DESCRIPTION
It responds slowly and we already have the ubuntu one, which is required
for ubuntu packages.