### PR TITLE
Fix Cargo registry write permissions with Docker

### DIFF
--- a/etc/entrypoint
+++ b/etc/entrypoint
@@ -25,6 +25,9 @@ for dir in \
 	chown ${APP_USER}:${APP_USER} ${dir}
 done
 
+# set write permissions on the Cargo registry (which can mutate due to external processes)
+chmod -R a+w ${CARGO_HOME}
+
 # detect main IP external address if not set/forced
 net_iface=$(awk '{ if ($2 == "00000000") { print $1; exit; } }' /proc/net/route)
 net_ip_addr=$(ip addr show dev ${net_iface} | awk -F'[ \t/]+' '/inet / { print $3; exit; }')


### PR DESCRIPTION
For some reason the permissions can change when the container is restarted, so this
sets the permissions when starting the container, instead of only at build time.