### PR TITLE
Install dav1d on Docker workers

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -58,6 +58,20 @@ RUN \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists
 
+# install nasm
+RUN \
+	DIR=/tmp/nasm && \
+	NASM_URL=http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm && \
+	NASM_VERSION=2.14.02-1 && \
+	NASM_DEB=nasm_${NASM_VERSION}_amd64.deb && \
+	NASM_SUM=5225d0654783134ae616f56ce8649e4df09cba191d612a0300cfd0494bb5a3ef && \
+	mkdir -p ${DIR} && \
+	cd ${DIR} && \
+	curl -O ${NASM_URL}/${NASM_DEB} && \
+	echo ${NASM_SUM} ${NASM_DEB} | sha256sum --check && \
+	dpkg -i ${NASM_DEB} && \
+	rm -rf ${DIR}
+
 # install daalatool
 ENV \
 	DAALATOOL_DIR=/opt/daalatool
@@ -83,6 +97,23 @@ RUN \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists && \
 	rm -vf /etc/ssh/ssh_host_*
+
+# install dav1d and dependencies
+ENV \
+	DAV1D_DIR=/opt/dav1d
+
+RUN \
+	apt-get install -y meson && \
+	git clone https://code.videolan.org/videolan/dav1d.git ${DAV1D_DIR} && \
+	cd ${DAV1D_DIR} && \
+	mkdir build && cd build && \
+	meson .. && \
+	ninja
+
+# clear package manager cache
+RUN \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists
 
 # set working directory
 WORKDIR /home/${APP_USER}


### PR DESCRIPTION
This is needed to decode rav1e output and detect desyncs. libaom is not installed on workers either, so the fallback to aomdec also fails, and the encoding process is aborted as a result.