### PR TITLE
Allow building codecs from any reference

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -396,7 +396,7 @@ app.post('/submit/job',function(req,res) {
     'task_type': 'video'
   }
 
-  const gerrit_detect_re = /I[0-9a-f].*/g;
+  const gerrit_detect_re = /I[0-9a-f]{40}/g;
   if (gerrit_detect_re.test(job.commit)) {
     res.status(400).send('Error: Commit looks like a Gerrit Change-Id. Use the commit hash instead.');
     return;

--- a/build_codec.sh
+++ b/build_codec.sh
@@ -99,8 +99,6 @@ case "${CODEC}" in
 
   rav1e)
     cd ${CODECS_SRC_DIR}/rav1e
-    git submodule sync
-    git submodule update --init
     cargo build --release
     ;;
 

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -68,15 +68,7 @@ export class SubmitJobFormComponent extends React.Component<{
         }
         break;
       case "commit":
-        let commit = job.commit.toLowerCase().trim();
-        if (commit.length >= 7 && commit.length <= 40) {
-          for (let i = 0; i < commit.length; i++) {
-            if ("abcdef0123456789".indexOf(commit[i]) < 0) {
-              return "error";
-            }
-          }
-          return "success";
-        }
+        if (job.commit) return "success";
         break;
       case "codec":
         if (this.state.codec.value) return "success";
@@ -162,7 +154,7 @@ export class SubmitJobFormComponent extends React.Component<{
       </FormGroup>
 
       <FormGroup validationState={this.getValidationState("commit")}>
-        <FormControl type="text" placeholder="Git Commit Hash e.g. 9368c05596d517c280146a1b815ec0ecc25e787c"
+        <FormControl type="text" placeholder="Git Commit Reference (Hash/Branch/Tag)"
           value={job.commit} onChange={this.onInputChange.bind(this, "commit")} />
       </FormGroup>
 

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -68,8 +68,11 @@ export class SubmitJobFormComponent extends React.Component<{
         }
         break;
       case "commit":
+        let commit = job.commit.trim();
+        if (commit.length === 41 && commit.charAt(0) === 'I') {
+          return "error"; // Gerrit Change-ID format, not a git reference
+        }
         if (job.commit) return "success";
-        break;
       case "codec":
         if (this.state.codec.value) return "success";
         break;


### PR DESCRIPTION
As far as I can tell, there's no reason to restrict the field to a commit, since the reference is fed directly to `git checkout`. This allows users to enter a tag or a branch name instead.

Also removes unnecessary build steps for rav1e, since it no longer uses a submodule.