### PR TITLE
[WIP] Add encoding mode support

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -116,6 +116,7 @@ function process_build_queue() {
     env['CODEC'] = build_job.codec;
     env['EXTRA_OPTIONS'] = build_job.extra_options;
     env['BUILD_OPTIONS'] = build_job.build_options;
+    env['ENCODING_MODE'] = build_job.encoding_mode;
     env['RUN_ID'] = build_job.run_id;
     env['APP_DIR'] = app_dir;
     env['CODECS_SRC_DIR'] = codecs_src_dir;
@@ -390,6 +391,7 @@ app.post('/submit/job',function(req,res) {
     'extra_options': req.body.extra_options,
     'build_options': req.body.build_options,
     'qualities': req.body.qualities,
+    'encoding_mode': req.body.encoding_mode,
     'master': req.body.master,
     'ab_compare': req.body.ab_compare,
     'save_encode': req.body.save_encode,

--- a/www/src/components/Job.tsx
+++ b/www/src/components/Job.tsx
@@ -145,6 +145,7 @@ export class JobComponent extends React.Component<JobProps, {
       details.push(keyValue("Commit", job.commit));
       details.push(keyValue("Task", job.task));
       details.push(keyValue("Qualities", job.qualities));
+      details.push(keyValue("Encoding Mode", job.encodingMode));
       details.push(keyValue("Run A/B Compare", job.runABCompare));
       details.push(keyValue("Save Encoded Files", job.saveEncodedFiles));
       details.push(keyValue("Status", JobStatus[job.status]));

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -14,6 +14,7 @@ export class SubmitJobFormComponent extends React.Component<{
     job: Job;
     set: Option;
     codec: Option;
+    encoding_mode: Option;
   }> {
   constructor() {
     super();
@@ -28,6 +29,7 @@ export class SubmitJobFormComponent extends React.Component<{
       job.extraOptions = template.extraOptions;
       job.nick = template.nick;
       job.qualities = template.qualities;
+      job.encodingMode = template.encodingMode;
       job.id = template.id;
       if (job.id.indexOf("@") > 0) {
         job.id = job.id.substr(0, job.id.indexOf("@"));
@@ -37,11 +39,13 @@ export class SubmitJobFormComponent extends React.Component<{
     }
     let task = job.task ? job.task : "objective-1-fast";
     let codec = job.codec ? job.codec : "av1";
+    let encoding_mode = job.encodingMode ? job.encodingMode : "quantizer";
     job.id += "@" + formatDate(new Date());
     this.state = {
       job: null,
       set: {label: task, value: task},
-      codec: {label: Job.codecs[codec], value: codec}
+      codec: {label: Job.codecs[codec], value: codec},
+      encoding_mode: {label: Job.encodingModes[encoding_mode], value: encoding_mode}
     } as any;
     job.saveEncodedFiles = true;
     this.setState({ job } as any);
@@ -56,7 +60,7 @@ export class SubmitJobFormComponent extends React.Component<{
     let job = this.state.job;
     switch (name) {
       case "all":
-        return ["id", "commit", "codec", "set", "nick", "qualities"].every(name =>
+        return ["id", "commit", "codec", "encoding_mode", "set", "nick", "qualities"].every(name =>
           (this.getValidationState(name) === "success")
         ) ? "success" : "error";
       case "id":
@@ -80,6 +84,11 @@ export class SubmitJobFormComponent extends React.Component<{
         break;
       case "codec":
         if (this.state.codec.value) return "success";
+        break;
+      case "encoding_mode":
+        if (this.state.encoding_mode.value) {
+          return "success";
+        }
         break;
       case "set":
         if (this.state.set.value) return "success";
@@ -120,13 +129,19 @@ export class SubmitJobFormComponent extends React.Component<{
     job.date = new Date();
     job.task = this.state.set.value;
     job.codec = this.state.codec.value;
+    job.encodingMode = this.state.encoding_mode.value;
     this.props.onCreate(job);
   }
   onCancel() {
     this.props.onCancel();
   }
+
   onChangeCodec(codec: Option) {
     this.setState({ codec } as any, () => { });
+  }
+
+  onChangeEncodingMode(encoding_mode: Option) {
+    this.setState({ encoding_mode } as any, () => { });
   }
 
   onChangeSet(set: Option) {
@@ -149,6 +164,12 @@ export class SubmitJobFormComponent extends React.Component<{
       codecOptions.push({ value: key, label: name });
     }
 
+    let encodingModeOptions = [];
+    for (let key in Job.encodingModes) {
+      let name = Job.encodingModes[key];
+      encodingModeOptions.push({ value: key, label: name });
+    }
+
     let setOptions = [];
     for (let key in Job.sets) {
       let set = Job.sets[key];
@@ -169,6 +190,11 @@ export class SubmitJobFormComponent extends React.Component<{
       <FormGroup validationState={this.getValidationState("codec")}>
         <ControlLabel>Codec</ControlLabel>
         <Select clearable={false} placeholder="Encoder" value={this.state.codec} options={codecOptions} onChange={this.onChangeCodec.bind(this)} />
+      </FormGroup>
+
+      <FormGroup validationState={this.getValidationState("encoding_mode")}>
+        <ControlLabel>Encoding Mode</ControlLabel>
+        <Select clearable={false} placeholder="Encoding Mode" value={this.state.encoding_mode} options={encodingModeOptions} onChange={this.onChangeEncodingMode.bind(this)} />
       </FormGroup>
 
       <FormGroup validationState={this.getValidationState("set")}>

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -340,6 +340,7 @@ export class Job {
   extraOptions: string = "";
   nick: string = "";
   qualities: string = "";
+  encodingMode: string = "";
   id: string = "";
   task: string = "";
   taskType: string = "";
@@ -477,6 +478,7 @@ export class Job {
     job.id = json.run_id;
     job.nick = json.nick;
     job.qualities = json.qualities || "";
+    job.encodingMode = json.encoding_mode;
     job.buildOptions = json.build_options;
     job.codec = json.codec;
     job.commit = json.commit;
@@ -506,6 +508,11 @@ export class Job {
     "rav1e": "rav1e",
     "svt-av1": "SVT-AV1",
     "vvc-vtm": "VVC VTM"
+  };
+
+  static encodingModes = {
+    "quantizer": "Target Quantizer",
+    "bitrate": "Target Bitrate (single-pass, rav1e only)",
   };
 
   static sets = {};
@@ -728,6 +735,7 @@ export class AppStore {
       extra_options: job.extraOptions,
       build_options: job.buildOptions,
       qualities: job.qualities,
+      encoding_mode: job.encodingMode,
       nick: job.nick,
       ab_compare: job.runABCompare,
       save_encode: job.saveEncodedFiles


### PR DESCRIPTION
This adds an encoding mode dropdown field when creating a run to set the encoding mode. It relies on implementations being available in `rd_tool`. Currently only single-pass target bitrate mode for rav1e is implemented. Before merging I want to dynamically hide encoding mode options depending on the selected codec.