### PR TITLE
docker: update to nasm 2.15.02

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,9 @@ RUN \
 RUN \
 	DIR=/tmp/nasm && \
 	NASM_URL=http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm && \
-	NASM_VERSION=2.14.02-1 && \
+	NASM_VERSION=2.15.02-1+b1 && \
 	NASM_DEB=nasm_${NASM_VERSION}_amd64.deb && \
-	NASM_SUM=5225d0654783134ae616f56ce8649e4df09cba191d612a0300cfd0494bb5a3ef && \
+	NASM_SUM=b454c064732c046ba025b82549833b3892ce85f2812d3addb8cbb06c6a47da8e && \
 	mkdir -p ${DIR} && \
 	cd ${DIR} && \
 	curl -O ${NASM_URL}/${NASM_DEB} && \


### PR DESCRIPTION
Rationale: 2.14.02-1 is no longer available from the debian mirror.