### PR TITLE
Fix BD-Rate offsets and formatting.

### DIFF
--- a/bd_rate_report.py
+++ b/bd_rate_report.py
@@ -204,7 +204,7 @@ else:
 
 met_name = ['PSNR', 'PSNRHVS', 'SSIM', 'FASTSSIM', 'CIEDE2000',
             'PSNR Cb', 'PSNR Cr', 'APSNR', 'APSNR Cb', 'APSNR Cr',
-            'MSSSIM', 'Time', 'VMAF_old',
+            'MSSSIM', 'Time', 'VMAF_old', 'Decoding Time',
              "PSNR Y (libvmaf)", "PSNR Cb (libvmaf)", "PSNR Cr (libvmaf)",
             "CIEDE2000 (libvmaf)", "SSIM (libvmaf)", "MS-SSIM (libvmaf)",
             "PSNR-HVS Y (libvmaf)", "PSNR-HVS Cb (libvmaf)", "PSNR-HVS Cr (libvmaf)",
@@ -212,11 +212,11 @@ met_name = ['PSNR', 'PSNRHVS', 'SSIM', 'FASTSSIM', 'CIEDE2000',
             ]
 met_index = {'PSNR': 0, 'PSNRHVS': 1, 'SSIM': 2, 'FASTSSIM': 3, 'CIEDE2000': 4,
              'PSNR Cb': 5, 'PSNR Cr': 6, 'APSNR': 7, 'APSNR Cb': 8, 'APSNR Cr':9,
-             'MSSSIM':10, 'Time':11, 'VMAF_old':12,
-             "PSNR Y (libvmaf)": 13, "PSNR Cb (libvmaf)": 14, "PSNR Cr (libvmaf)": 15,
-             "CIEDE2000 (libvmaf)": 16, "SSIM (libvmaf)": 17, "MS-SSIM (libvmaf)": 18,
-             "PSNR-HVS Y (libvmaf)": 19, "PSNR-HVS Cb (libvmaf)": 20, "PSNR-HVS Cr (libvmaf)": 21,
-             "PSNR-HVS (libvmaf)": 22, "VMAF": 23, "VMAF-NEG": 24}
+             'MSSSIM':10, 'Time':11, 'VMAF_old':12, 'Decoding Time': 13,
+             "PSNR Y (libvmaf)": 14, "PSNR Cb (libvmaf)": 15, "PSNR Cr (libvmaf)": 16,
+             "CIEDE2000 (libvmaf)": 17, "SSIM (libvmaf)": 18, "MS-SSIM (libvmaf)": 19,
+             "PSNR-HVS Y (libvmaf)": 20, "PSNR-HVS Cb (libvmaf)": 21, "PSNR-HVS Cr (libvmaf)": 22,
+             "PSNR-HVS (libvmaf)": 23, "VMAF": 24, "VMAF-NEG": 25}
 
 q_not_found = False
 

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -40,7 +40,7 @@ interface VideoReportProps {
   filterQualities?: number [];
 }
 
-let displayedBDRateMetrics = ['PSNR', 'PSNR HVS', 'SSIM', 'CIEDE 2000', 'APSNR', 'MS SSIM', 'VMAF'];
+let displayedBDRateMetrics = ['PSNR Y (libvmaf)', 'PSNR Cb (libvmaf)', 'PSNR Cr (libvmaf)', 'CIEDE2000 (libvmaf)', 'SSIM (libvmaf)', 'MS-SSIM (libvmaf)', 'PSNR-HVS Y (libvmaf)', 'PSNR-HVS Cb (libvmaf)', 'PSNR-HVS Cr (libvmaf)', 'VMAF', 'VMAF-NEG'];
 
 // this is the chart of raw metric scores underneath the graph
 
@@ -111,7 +111,7 @@ export class VideoReportComponent extends React.Component<VideoReportProps, {
       rows.push(<tr key={quality}>{cols}</tr>);
     });
     let reportUrl = hasIvfs ? this.props.job.reportUrl(this.props.name) : this.props.job.totalReportUrl();
-    let table = <div>
+    let table = <div style={{overflowY: "scroll"}}>
       <Table striped bordered condensed hover style={{width: "100%"}}>
         <thead>
           <tr>
@@ -402,16 +402,18 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
         </div>
         {errors}
         {textReport}
-        <Table striped bordered condensed hover style={{width: "100%"}}>
-          <thead>
-            <tr>
-              {headers}
-            </tr>
-          </thead>
-          <tbody>
-            {rows}
-          </tbody>
-        </Table>
+        <div style={{overflowY: "scroll"}}>
+          <Table striped bordered condensed hover style={{width: "100%"}}>
+            <thead>
+              <tr>
+                {headers}
+              </tr>
+            </thead>
+            <tbody>
+              {rows}
+            </tbody>
+          </Table>
+        </div>
       </Panel>
   }
 }


### PR DESCRIPTION
Set the default displayed metrics to the  AV2 metrics.

Set overflow-y for the raw and bdrate tables.