### PR TITLE
Update libvmaf to v2.2.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,7 +245,7 @@ RUN \
 # install VMAF
 ENV \
 	VMAF_DIR=/opt/vmaf \
-	VMAF_VERSION=v2.2.0
+	VMAF_VERSION=v2.2.1
 
 RUN \
 	mkdir -p ${VMAF_DIR} && \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -151,7 +151,7 @@ RUN \
 # install VMAF
 ENV \
 	VMAF_DIR=/opt/vmaf \
-	VMAF_VERSION=v2.2.0
+	VMAF_VERSION=v2.2.1
 
 RUN \
 	mkdir -p ${VMAF_DIR} && \


### PR DESCRIPTION
This is required for the new version of the AOM CTC.