### PR TITLE
Update minimum rust version in Docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ENV \
 
 # install rust
 RUN \
-	RUST_VERSION=1.42.0 && \
+	RUST_VERSION=1.51.0 && \
 	curl -sSf --output /tmp/rustup-init https://static.rust-lang.org/rustup/archive/1.14.0/x86_64-unknown-linux-gnu/rustup-init && \
 	chmod +x /tmp/rustup-init && \
 	/tmp/rustup-init -y --no-modify-path --default-toolchain ${RUST_VERSION} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV \
 	LANG=C.UTF-8 \
 	LANGUAGE=C.UTF-8 \
 	DEBIAN_FRONTEND=noninteractive \
-	GPG_SERVERS="ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80"
+	GPG_SERVERS="hkp://keys.openpgp.org:80 hkp://p80.pool.sks-keyservers.net:80 hkp://keyserver.ubuntu.com:80"
 
 # add runtime user
 RUN \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -81,7 +81,7 @@ ENV \
 
 # install rust
 RUN \
-	RUST_VERSION=1.42.0 && \
+	RUST_VERSION=1.51.0 && \
 	curl -sSf --output /tmp/rustup-init https://static.rust-lang.org/rustup/archive/1.14.0/x86_64-unknown-linux-gnu/rustup-init && \
 	chmod +x /tmp/rustup-init && \
 	/tmp/rustup-init -y --no-modify-path --default-toolchain ${RUST_VERSION} && \


### PR DESCRIPTION
Fix same problem as e338be610a70d79e42ba27647108129438d6682b in the
rav1e tree; new version of clamp crate can't build with older Rust.
Update Rust in Docker build to 1.51.0.