### PR TITLE
Update the Rust version to 1.59

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ ENV \
 
 # install rust
 RUN \
-	RUST_VERSION=1.51.0 && \
+	RUST_VERSION=1.59.0 && \
 	curl -sSf --output /tmp/rustup-init https://static.rust-lang.org/rustup/archive/1.14.0/x86_64-unknown-linux-gnu/rustup-init && \
 	chmod +x /tmp/rustup-init && \
 	/tmp/rustup-init -y --no-modify-path --default-toolchain ${RUST_VERSION} && \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -94,7 +94,7 @@ ENV \
 # install rust
 RUN \
 	ARCH=`uname -m` && \
-	RUST_VERSION=1.51.0 && \
+	RUST_VERSION=1.59.0 && \
 	if [ "$ARCH" = "x86_64" ]; then \
 		curl -sSf --output /tmp/rustup-init  https://static.rust-lang.org/rustup/archive/1.14.0/x86_64-unknown-linux-gnu/rustup-init; \
 	else \


### PR DESCRIPTION
This is needed for the latest version of rav1e to compile.