### PR TITLE
Add ARM building support for Docker and other misc updates

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -94,12 +94,8 @@ ENV \
 # install rust
 RUN \
 	ARCH=`uname -m` && \
-	RUST_VERSION=1.59.0 && \
-	if [ "$ARCH" = "x86_64" ]; then \
-		curl -sSf --output /tmp/rustup-init  https://static.rust-lang.org/rustup/archive/1.14.0/x86_64-unknown-linux-gnu/rustup-init; \
-	else \
-		curl -sSf --output /tmp/rustup-init  https://static.rust-lang.org/rustup/archive/1.14.0/aarch64-unknown-linux-gnu/rustup-init; \
-	fi && \
+	RUST_VERSION=1.64.0 && \
+	curl -sSf --output /tmp/rustup-init https://static.rust-lang.org/rustup/archive/1.25.0/${ARCH}-unknown-linux-gnu/rustup-init && \
 	chmod +x /tmp/rustup-init && \
 	/tmp/rustup-init -y --no-modify-path --default-toolchain ${RUST_VERSION} && \
 	rm -vf /tmp/rustup-init
@@ -129,7 +125,7 @@ RUN \
 # install hdrtools
 ENV \
 	HDRTOOLS_DIR=/opt/hdrtools \
-	HDRTOOLS_VERSION=0.21
+	HDRTOOLS_VERSION=0.22
 
 RUN \
 	ARCH=`uname -m` && \
@@ -171,13 +167,13 @@ RUN \
 	git clone https://code.videolan.org/videolan/dav1d.git ${DAV1D_DIR} && \
 	cd ${DAV1D_DIR} && \
 	mkdir build && cd build && \
-	meson .. && \
-	ninja
+	meson .. --default-library static --buildtype release && \
+	ninja install
 
 # install VMAF
 ENV \
 	VMAF_DIR=/opt/vmaf \
-	VMAF_VERSION=v2.2.1
+	VMAF_VERSION=v2.3.1
 
 RUN \
 	mkdir -p ${VMAF_DIR} && \

--- a/etc/entrypoint
+++ b/etc/entrypoint
@@ -84,6 +84,14 @@ if [ ! -d "${CODECS_SRC_DIR}/av1" ]; then
 	ln -s ${CODECS_SRC_DIR}/av1 ${CODECS_SRC_DIR}/av1-rt
 fi
 
+if [ ! -d "${CODECS_SRC_DIR}/av2" ]; then
+	gosu ${APP_USER}:${APP_USER} git clone https://gitlab.com/AOMediaCodec/avm.git ${CODECS_SRC_DIR}/av2
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ra
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ra-st
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ld
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ai
+fi
+
 if [ ! -d "${CODECS_SRC_DIR}/daala" ]; then
 	gosu ${APP_USER}:${APP_USER} git clone https://github.com/xiph/daala.git ${CODECS_SRC_DIR}/daala
 fi
@@ -93,7 +101,7 @@ if [ ! -d "${CODECS_SRC_DIR}/rav1e" ]; then
 fi
 
 if [ ! -d "${CODECS_SRC_DIR}/svt-av1" ]; then
-	gosu ${APP_USER}:${APP_USER} git clone https://github.com/OpenVisualCloud/SVT-AV1.git ${CODECS_SRC_DIR}/svt-av1
+	gosu ${APP_USER}:${APP_USER} git clone https://gitlab.com/AOMediaCodec/SVT-AV1.git ${CODECS_SRC_DIR}/svt-av1
 fi
 
 if [ ! -d "${CODECS_SRC_DIR}/vvc-vtm" ]; then
@@ -193,6 +201,31 @@ fi
 if [ -z "${SSH_PRIVKEY_FILE:-}" ]; then
 	export SSH_PRIVKEY_FILE=${CONFIG_DIR}/awcy.pem
 fi
+
+# Update the git to have all folders as safe.dir for git safety mechansim.
+git config --global --add safe.directory '*'
+touch /home/${APP_USER}/.gitconfig
+cat >/home/${APP_USER}/.gitconfig <<-EOF
+	[safe]
+		directory = *
+	EOF
+chown xiph /home/${APP_USER}/.gitconfig
+
+# Explictly Set Permissions to be sure we got it right
+export SSH_PRIVKEY_FILE=${CONFIG_DIR}/awcy.pem
+echo $SSH_PRIVKEY_FILE
+
+## Add Key to agent
+eval `ssh-agent -s`
+ssh-add /data/conf/awcy.pem
+ssh-add -l
+
+## Update permissions
+chmod 700 /home/${APP_USER}/.ssh
+chmod 600 /home/${APP_USER}/.ssh/authorized_keys
+chown -R ${APP_USER}:${APP_USER} /home/${APP_USER}/.ssh
+chown -R ${APP_USER}:${APP_USER} /home/${APP_USER}/.ssh/authorized_keys
+chown -R ${APP_USER}:${APP_USER} $SSH_PRIVKEY_FILE
 
 # run runit services
 exec tini -g -- /usr/bin/runsvdir -P /etc/service


### PR DESCRIPTION
This PR introduces
- support for building Docker for ARM target, this is tested on M1 mac, 
- ~Updates some packages and locks to make sure it is compatible with modern changes, this is also disabling IRC module as I was not able to build it anymore as we are on steps to migrate to Email based notifcation but would be nice to make it not broken.~
- Migrates to latest CTCv3 VMAF, HDRTools versions

I have removed www/ irc module disabling in this, so we can land this first. 