### PR TITLE
Initial Support for AOM CTC Excel Template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -278,6 +278,11 @@ RUN \
 # add scripts
 ADD *.m *.sh *.py ${APP_DIR}/
 
+# AOM_CTC: Install Openpyxl
+RUN \
+	pip3 install openpyxl
+
+
 # environment variables
 ENV \
 	CONFIG_DIR=/data/conf \

--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -384,6 +384,38 @@ app.get('/bd_rate',function(req,res) {
   }
 });
 
+// AOM-CTC XLSM Template endpoint
+// Requires Two Jobs as arguments.
+app.get('/ctc_report.xlsm',function(req,res) {
+  if (!req.query['a']) {
+    res.send('No Run A specified');
+    return;
+  }
+  if (!req.query['b']) {
+    res.send('No Run B specified');
+    return;
+  }
+  const a = path.basename(String(req.query['a']));
+  const b = path.basename(String(req.query['b']));
+  const a_file = runs_dst_dir+'/'+a;
+  const b_file = runs_dst_dir+'/'+b;
+  let filename_to_send = 'CTC_Regular_v0-'+a+'-'+b+'.xlsm';
+  console.log(filename_to_send);
+  console.log(runs_dst_dir)
+  res.header("Content-Type", "application/vnd.ms-excel.sheet.macroEnabled.12");
+  res.header('Content-Disposition', 'attachment; filename="'+filename_to_send+'"');
+  cp.execFile('./csv_export.py',[a_file, '--ctc_export', '--run_b='+b_file],
+              {},
+              function(error,stdout,stderr) {
+                if (error) {
+                  res.send(stdout+stderr);
+                  throw error;
+                } else {
+                  res.sendFile(path.join(runs_dst_dir, '/ctc_results/'+filename_to_send));
+                }
+              });
+});
+
 app.use('/submit',check_key);
 
 app.use('/submit/check',function(req,res) {

--- a/csv_export.py
+++ b/csv_export.py
@@ -140,96 +140,100 @@ def save_ctc_export(run_path, cmd_args):
         w = csv.writer(csv_writer_obj, dialect="excel")
 
     w.writerow(row_header)
-    for video in videos:
-        v = open(os.path.join(videos_dir, video), "rb")
-        line = v.readline().decode("utf-8")
-        fps_n, fps_d = re.search(r"F([0-9]*)\:([0-9]*)", line).group(1, 2)
-        width = re.search(r"W([0-9]*)", line).group(1)
-        height = re.search(r"H([0-9]*)", line).group(1)
-        current_video_set = info_data["task"]
-        if 'aomctc' in current_video_set:
-            normalized_set = current_video_set.split('-')[1].upper()
-        a = loadtxt(os.path.join(run_path, task, video + "-daala.out"))
-        for row in a:
-            frames = int(row[1]) / int(width) / int(height)
-            if info_data["codec"] == "av2-as":
-                w.writerow(
-                    [
-                        "AS",  # TestCfg
-                        "aom",  # EncodeMethod
-                        info_data["run_id"],  # CodecName
-                        "",  # EncodePreset
-                        info_data["task"],  # Class
-                        video,  # name
-                        "3840x2160",  # OrigRes
-                        "",  # FPS
-                        10,  # BitDepth
-                        str(width) + "x" + str(height),  # CodedRes
-                        row[0],  # qp
-                        int(row[2])
-                        * 8.0
-                        * float(fps_n)
-                        / float(fps_d)
-                        / frames
-                        / 1000.0,  # bitrate
-                        row[met_index["PSNR Y (libvmaf)"] + 3],
-                        row[met_index["PSNR Cb (libvmaf)"] + 3],
-                        row[met_index["PSNR Cr (libvmaf)"] + 3],
-                        row[met_index["SSIM (libvmaf)"] + 3],
-                        row[met_index["MS-SSIM (libvmaf)"] + 3],
-                        row[met_index["VMAF"] + 3],
-                        row[met_index["VMAF-NEG"] + 3],
-                        row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
-                        row[met_index["CIEDE2000 (libvmaf)"] + 3],
-                        row[met_index["APSNR Y (libvmaf)"] + 3],
-                        row[met_index["APSNR Cb (libvmaf)"] + 3],
-                        row[met_index["APSNR Cr (libvmaf)"] + 3],
-                        row[met_index["Encoding Time"] + 3],
-                        row[met_index["Decoding Time"] + 3],
-                    ]
-                )
-            else:
-                w.writerow(
-                    [
-                        "RA",  # TestCfg # TODO: FIXME
-                        "aom",  # EncodeMethod
-                        info_data["run_id"],  # CodecName
-                        "",  # EncodePreset #TODO: FIXME
-                        normalized_set,  # Class
-                        video,  # name
-                        str(width) + "x" + str(height),  # OrigRes
-                        str(float(fps_n) / float(fps_d)),  # FPS
-                        10,  # BitDepth #TODO: FIXME
-                        str(width) + "x" + str(height),  # CodedRes
-                        int(row[0]),  # qp
-                        int(row[2])
-                        * 8.0
-                        * float(fps_n)
-                        / float(fps_d)
-                        / frames
-                        / 1000.0,  # bitrate
-                        row[met_index["PSNR Y (libvmaf)"] + 3],
-                        row[met_index["PSNR Cb (libvmaf)"] + 3],
-                        row[met_index["PSNR Cr (libvmaf)"] + 3],
-                        row[met_index["SSIM (libvmaf)"] + 3],
-                        row[met_index["MS-SSIM (libvmaf)"] + 3],
-                        row[met_index["VMAF"] + 3],
-                        row[met_index["VMAF-NEG"] + 3],
-                        row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
-                        row[met_index["CIEDE2000 (libvmaf)"] + 3],
-                        row[met_index["APSNR Y (libvmaf)"] + 3],
-                        row[met_index["APSNR Cb (libvmaf)"] + 3],
-                        row[met_index["APSNR Cr (libvmaf)"] + 3],
-                        row[met_index["CAMBI (libvmaf)"] + 3],
-                        row[met_index["Encoding Time"] + 3],
-                        row[met_index["Decoding Time"] + 3],
-                        "",  # ENCInstr
-                        "",  # DecInstr
-                        "",  # EncCycles
-                        "",  # DecCycles
-                        "",  # EncMD5
-                    ]
-                )
+    try:
+        for video in videos:
+            v = open(os.path.join(videos_dir, video), "rb")
+            line = v.readline().decode("utf-8")
+            fps_n, fps_d = re.search(r"F([0-9]*)\:([0-9]*)", line).group(1, 2)
+            width = re.search(r"W([0-9]*)", line).group(1)
+            height = re.search(r"H([0-9]*)", line).group(1)
+            current_video_set = info_data["task"]
+            if 'aomctc' in current_video_set:
+                normalized_set = current_video_set.split('-')[1].upper()
+            a = loadtxt(os.path.join(run_path, task, video + "-daala.out"))
+            for row in a:
+                frames = int(row[1]) / int(width) / int(height)
+                if info_data["codec"] == "av2-as":
+                    w.writerow(
+                        [
+                            "AS",  # TestCfg
+                            "aom",  # EncodeMethod
+                            info_data["run_id"],  # CodecName
+                            "",  # EncodePreset
+                            info_data["task"],  # Class
+                            video,  # name
+                            "3840x2160",  # OrigRes
+                            "",  # FPS
+                            10,  # BitDepth
+                            str(width) + "x" + str(height),  # CodedRes
+                            row[0],  # qp
+                            int(row[2])
+                            * 8.0
+                            * float(fps_n)
+                            / float(fps_d)
+                            / frames
+                            / 1000.0,  # bitrate
+                            row[met_index["PSNR Y (libvmaf)"] + 3],
+                            row[met_index["PSNR Cb (libvmaf)"] + 3],
+                            row[met_index["PSNR Cr (libvmaf)"] + 3],
+                            row[met_index["SSIM (libvmaf)"] + 3],
+                            row[met_index["MS-SSIM (libvmaf)"] + 3],
+                            row[met_index["VMAF"] + 3],
+                            row[met_index["VMAF-NEG"] + 3],
+                            row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
+                            row[met_index["CIEDE2000 (libvmaf)"] + 3],
+                            row[met_index["APSNR Y (libvmaf)"] + 3],
+                            row[met_index["APSNR Cb (libvmaf)"] + 3],
+                            row[met_index["APSNR Cr (libvmaf)"] + 3],
+                            row[met_index["Encoding Time"] + 3],
+                            row[met_index["Decoding Time"] + 3],
+                        ]
+                    )
+                else:
+                    w.writerow(
+                        [
+                            "RA",  # TestCfg # TODO: FIXME
+                            "aom",  # EncodeMethod
+                            info_data["run_id"],  # CodecName
+                            "",  # EncodePreset #TODO: FIXME
+                            normalized_set,  # Class
+                            video,  # name
+                            str(width) + "x" + str(height),  # OrigRes
+                            str(float(fps_n) / float(fps_d)),  # FPS
+                            10,  # BitDepth #TODO: FIXME
+                            str(width) + "x" + str(height),  # CodedRes
+                            int(row[0]),  # qp
+                            int(row[2])
+                            * 8.0
+                            * float(fps_n)
+                            / float(fps_d)
+                            / frames
+                            / 1000.0,  # bitrate
+                            row[met_index["PSNR Y (libvmaf)"] + 3],
+                            row[met_index["PSNR Cb (libvmaf)"] + 3],
+                            row[met_index["PSNR Cr (libvmaf)"] + 3],
+                            row[met_index["SSIM (libvmaf)"] + 3],
+                            row[met_index["MS-SSIM (libvmaf)"] + 3],
+                            row[met_index["VMAF"] + 3],
+                            row[met_index["VMAF-NEG"] + 3],
+                            row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
+                            row[met_index["CIEDE2000 (libvmaf)"] + 3],
+                            row[met_index["APSNR Y (libvmaf)"] + 3],
+                            row[met_index["APSNR Cb (libvmaf)"] + 3],
+                            row[met_index["APSNR Cr (libvmaf)"] + 3],
+                            row[met_index["CAMBI (libvmaf)"] + 3],
+                            row[met_index["Encoding Time"] + 3],
+                            row[met_index["Decoding Time"] + 3],
+                            "",  # ENCInstr
+                            "",  # DecInstr
+                            "",  # EncCycles
+                            "",  # DecCycles
+                            "",  # EncMD5
+                        ]
+                    )
+    except BaseException:
+        # This allows partial rendering of CSV + XLS Reports
+        pass
     if cmd_args.ctc_export:
         csv_writer_obj.close()
 

--- a/csv_export.py
+++ b/csv_export.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import csv
@@ -6,7 +6,8 @@ import json
 import os
 import re
 import sys
-
+import shutil
+from openpyxl import load_workbook
 from numpy import *
 
 # offset by 3
@@ -40,151 +41,271 @@ met_index = {
     "APSNR Y (libvmaf)": 26,
     "APSNR Cb (libvmaf)": 27,
     "APSNR Cr (libvmaf)": 28,
+    "CAMBI (libvmaf)": 29,
 }
 
-parser = argparse.ArgumentParser(description="Generate CTC CSV version of .out files")
-parser.add_argument("run", nargs=1, help="Run folder")
-args = parser.parse_args()
+# row_id for different sets inside template.
+start_rows = {
+    'A1': 2,
+    'A2': 50,
+    'A3': 182,
+    'A4': 230,
+    'A5': 266,
+    'B1': 290,
+    'B2': 350,
+    'G1': 416,
+    'G2': 440,
+    'E': 482
+}
 
-info_data = json.load(open(args.run[0] + "/info.json"))
-task = info_data["task"]
-sets = json.load(open(os.path.join(os.getenv("CONFIG_DIR", "rd_tool"), "sets.json")))
-videos = sets[task]["sources"]
-# sort name ascending, resolution descending
-if task != "av2-a1-4k-as":
-    videos.sort(key=lambda s: s.lower())
-else:
-    videos.sort(
-        key=lambda x: x.split("_")[0]
-        + "%08d" % (100000 - int(x.split("_")[1].split("x")[0]))
-    )
-videos_dir = os.path.join(
-    os.getenv("MEDIA_DIR", "/mnt/runs/sets"), task
-)  # for getting framerate
+run_cfgs = ['RA', 'LD', 'AI', 'AS']
 
-w = csv.writer(sys.stdout, dialect="excel")
-if info_data["codec"] == "av2-as":
-    w.writerow(
-        [
-            "TestCfg",
-            "EncodeMethod",
-            "CodecName",
-            "EncodePreset",
-            "Class",
-            "Name",
-            "OrigRes",
-            "FPS",
-            "BitDepth",
-            "CodedRes",
-            "QP",
-            "Bitrate (kbps)",
-            "PSNR Y",
-            "PSNR U",
-            "PSNR V",
-            "SSIM",
-            "MS-SSIM",
-            "VMAF",
-            "nVMAF",
-            "PSNR-HVS Y",
-            "DE2K",
-            "APSNR Y",
-            "APSNR U",
-            "APSNR V",
-            "Enc T [s]",
-            "Dec T [s]",
-        ]
-    )
-else:
-    w.writerow(
-        [
-            "Video",
-            "QP",
-            "Bitrate (kbps)",
-            "PSNR Y",
-            "PSNR U",
-            "PSNR V",
-            "SSIM",
-            "MS-SSIM",
-            "VMAF",
-            "nVMAF",
-            "PSNR-HVS Y",
-            "DE2K",
-            "APSNR Y",
-            "APSNR U",
-            "APSNR V",
-            "Enc T [s]",
-            "Dec T [s]",
-        ]
-    )
-for video in videos:
-    v = open(os.path.join(videos_dir, video), "rb")
-    line = v.readline().decode("utf-8")
-    fps_n, fps_d = re.search(r"F([0-9]*)\:([0-9]*)", line).group(1, 2)
-    width = re.search(r"W([0-9]*)", line).group(1)
-    height = re.search(r"H([0-9]*)", line).group(1)
-    a = loadtxt(os.path.join(args.run[0], task, video + "-daala.out"))
-    for row in a:
-        frames = int(row[1]) / int(width) / int(height)
-        if info_data["codec"] == "av2-as":
-            w.writerow(
-                [
-                    "AS",  # TestCfg
-                    "aom",  # EncodeMethod
-                    info_data["run_id"],  # CodecName
-                    "",  # EncodePreset
-                    info_data["task"],  # Class
-                    video,  # name
-                    "3840x2160",  # OrigRes
-                    "",  # FPS
-                    10,  # BitDepth
-                    str(width) + "x" + str(height),  # CodedRes
-                    row[0],  # qp
-                    int(row[2])
-                    * 8.0
-                    * float(fps_n)
-                    / float(fps_d)
-                    / frames
-                    / 1000.0,  # bitrate
-                    row[met_index["PSNR Y (libvmaf)"] + 3],
-                    row[met_index["PSNR Cb (libvmaf)"] + 3],
-                    row[met_index["PSNR Cr (libvmaf)"] + 3],
-                    row[met_index["SSIM (libvmaf)"] + 3],
-                    row[met_index["MS-SSIM (libvmaf)"] + 3],
-                    row[met_index["VMAF"] + 3],
-                    row[met_index["VMAF-NEG"] + 3],
-                    row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
-                    row[met_index["CIEDE2000 (libvmaf)"] + 3],
-                    row[met_index["APSNR Y (libvmaf)"] + 3],
-                    row[met_index["APSNR Cb (libvmaf)"] + 3],
-                    row[met_index["APSNR Cr (libvmaf)"] + 3],
-                    row[met_index["Encoding Time"] + 3],
-                    row[met_index["Decoding Time"] + 3],
-                ]
-            )
-        else:
-            w.writerow(
-                [
-                    video,
-                    row[0],  # qp
-                    int(row[2])
-                    * 8.0
-                    * float(fps_n)
-                    / float(fps_d)
-                    / frames
-                    / 1000.0,  # bitrate
-                    row[met_index["PSNR Y (libvmaf)"] + 3],
-                    row[met_index["PSNR Cb (libvmaf)"] + 3],
-                    row[met_index["PSNR Cr (libvmaf)"] + 3],
-                    row[met_index["SSIM (libvmaf)"] + 3],
-                    row[met_index["MS-SSIM (libvmaf)"] + 3],
-                    row[met_index["VMAF"] + 3],
-                    row[met_index["VMAF-NEG"] + 3],
-                    row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
-                    row[met_index["CIEDE2000 (libvmaf)"] + 3],
-                    row[met_index["APSNR Y (libvmaf)"] + 3],
-                    row[met_index["APSNR Cb (libvmaf)"] + 3],
-                    row[met_index["APSNR Cr (libvmaf)"] + 3],
-                    row[met_index["Encoding Time"] + 3],
-                    row[met_index["Decoding Time"] + 3],
-                ]
-            )
+row_header = [
+    "TestCfg",
+    "EncodeMethod",
+    "CodecName",
+    "EncodePreset",
+    "Class",
+    "Name",
+    "OrigRes",
+    "FPS",
+    "BitDepth",
+    "CodedRes",
+    "QP",
+    "Bitrate(kbps)",
+    "PSNR_Y",
+    "PSNR_U",
+    "PSNR_V",
+    "SSIM_Y(dB)",
+    "MS-SSIM_Y(dB)",
+    "VMAF_Y",
+    "VMAF_Y-NEG",
+    "PSNR-HVS",
+    "CIEDE2000",
+    "APSNR_Y",
+    "APSNR_U",
+    "APSNR_V",
+    "CAMBI",
+    "EncT[s]",
+    "DecT[s]",
+    "EncInstr",
+    "DecInstr",
+    "EncCycles",
+    "DecCycles",
+    "EncMD5"
+]
+
+
+class Logger(object):
+    def __init__(self, run_path, args):
+        self.this_args = args
+        if not args.ctc_export:
+            self.terminal = sys.stdout
+        self.log = open(run_path + "/csv_export.csv", "w")
+
+    def write(self, message):
+        if not self.this_args.ctc_export:
+            self.terminal.write(message)
+        self.log.write(message)
+
+    def flush(self):
+        if not self.this_args.ctc_export:
+            self.terminal.flush()
+        self.log.flush()
+
+
+def save_ctc_export(run_path, cmd_args):
+    info_data = json.load(open(run_path + "/info.json"))
+    task = info_data["task"]
+    sets = json.load(
+        open(os.path.join(os.getenv("CONFIG_DIR", "rd_tool"), "sets.json")))
+    videos = sets[task]["sources"]
+    # sort name ascending, resolution descending
+    if task != "av2-a1-4k-as":
+        videos.sort(key=lambda s: s.lower())
+    else:
+        videos.sort(
+            key=lambda x: x.split("_")[0]
+            + "%08d" % (100000 - int(x.split("_")[1].split("x")[0]))
+        )
+    videos_dir = os.path.join(
+        os.getenv("MEDIAS_SRC_DIR", "/mnt/runs/sets"), task
+    )  # for getting framerate
+
+    if not cmd_args.ctc_export:
+        sys.stdout = Logger(run_path, cmd_args)
+        w = csv.writer(sys.stdout, dialect="excel")
+    else:
+        csv_writer_obj = open(run_path + "/csv_export.csv", 'w')
+        w = csv.writer(csv_writer_obj, dialect="excel")
+
+    w.writerow(row_header)
+    for video in videos:
+        v = open(os.path.join(videos_dir, video), "rb")
+        line = v.readline().decode("utf-8")
+        fps_n, fps_d = re.search(r"F([0-9]*)\:([0-9]*)", line).group(1, 2)
+        width = re.search(r"W([0-9]*)", line).group(1)
+        height = re.search(r"H([0-9]*)", line).group(1)
+        current_video_set = info_data["task"]
+        if 'aomctc' in current_video_set:
+            normalized_set = current_video_set.split('-')[1].upper()
+        a = loadtxt(os.path.join(run_path, task, video + "-daala.out"))
+        for row in a:
+            frames = int(row[1]) / int(width) / int(height)
+            if info_data["codec"] == "av2-as":
+                w.writerow(
+                    [
+                        "AS",  # TestCfg
+                        "aom",  # EncodeMethod
+                        info_data["run_id"],  # CodecName
+                        "",  # EncodePreset
+                        info_data["task"],  # Class
+                        video,  # name
+                        "3840x2160",  # OrigRes
+                        "",  # FPS
+                        10,  # BitDepth
+                        str(width) + "x" + str(height),  # CodedRes
+                        row[0],  # qp
+                        int(row[2])
+                        * 8.0
+                        * float(fps_n)
+                        / float(fps_d)
+                        / frames
+                        / 1000.0,  # bitrate
+                        row[met_index["PSNR Y (libvmaf)"] + 3],
+                        row[met_index["PSNR Cb (libvmaf)"] + 3],
+                        row[met_index["PSNR Cr (libvmaf)"] + 3],
+                        row[met_index["SSIM (libvmaf)"] + 3],
+                        row[met_index["MS-SSIM (libvmaf)"] + 3],
+                        row[met_index["VMAF"] + 3],
+                        row[met_index["VMAF-NEG"] + 3],
+                        row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
+                        row[met_index["CIEDE2000 (libvmaf)"] + 3],
+                        row[met_index["APSNR Y (libvmaf)"] + 3],
+                        row[met_index["APSNR Cb (libvmaf)"] + 3],
+                        row[met_index["APSNR Cr (libvmaf)"] + 3],
+                        row[met_index["Encoding Time"] + 3],
+                        row[met_index["Decoding Time"] + 3],
+                    ]
+                )
+            else:
+                w.writerow(
+                    [
+                        "RA",  # TestCfg # TODO: FIXME
+                        "aom",  # EncodeMethod
+                        info_data["run_id"],  # CodecName
+                        "",  # EncodePreset #TODO: FIXME
+                        normalized_set,  # Class
+                        video,  # name
+                        str(width) + "x" + str(height),  # OrigRes
+                        str(float(fps_n) / float(fps_d)),  # FPS
+                        10,  # BitDepth #TODO: FIXME
+                        str(width) + "x" + str(height),  # CodedRes
+                        int(row[0]),  # qp
+                        int(row[2])
+                        * 8.0
+                        * float(fps_n)
+                        / float(fps_d)
+                        / frames
+                        / 1000.0,  # bitrate
+                        row[met_index["PSNR Y (libvmaf)"] + 3],
+                        row[met_index["PSNR Cb (libvmaf)"] + 3],
+                        row[met_index["PSNR Cr (libvmaf)"] + 3],
+                        row[met_index["SSIM (libvmaf)"] + 3],
+                        row[met_index["MS-SSIM (libvmaf)"] + 3],
+                        row[met_index["VMAF"] + 3],
+                        row[met_index["VMAF-NEG"] + 3],
+                        row[met_index["PSNR-HVS Y (libvmaf)"] + 3],
+                        row[met_index["CIEDE2000 (libvmaf)"] + 3],
+                        row[met_index["APSNR Y (libvmaf)"] + 3],
+                        row[met_index["APSNR Cb (libvmaf)"] + 3],
+                        row[met_index["APSNR Cr (libvmaf)"] + 3],
+                        row[met_index["CAMBI (libvmaf)"] + 3],
+                        row[met_index["Encoding Time"] + 3],
+                        row[met_index["Decoding Time"] + 3],
+                        "",  # ENCInstr
+                        "",  # DecInstr
+                        "",  # EncCycles
+                        "",  # DecCycles
+                        "",  # EncMD5
+                    ]
+                )
+    if cmd_args.ctc_export:
+        csv_writer_obj.close()
+
+
+def write_xls_rows(run_path, start_id, this_sheet):
+    run_file = open(run_path + '/csv_export.csv', 'r')
+    run_reader = csv.reader(run_file)
+    next(run_reader)
+    this_row = start_id
+    for this_line in run_reader:
+        this_col = 1
+        for this_values in this_line:
+            this_cell = this_sheet.cell(row=this_row, column=this_col)
+            if this_col >= 12 and this_col <= 30 and this_values != "":
+                this_cell.value = float(this_values)
+            else:
+                this_cell.value = this_values
+            this_col += 1
+        this_row += 1
+    run_file.close()
+
+
+def write_xls_file(run_a, run_b):
+    xls_template = os.path.join(
+        os.getenv("CONFIG_DIR", "rd_tool"), 'AOM_CWG_Regular_CTCv3_v7.2.xlsm')
+    run_a_info = json.load(open(run_a + "/info.json"))
+    run_b_info = json.load(open(run_b + "/info.json"))
+    run_id_a = run_a_info["run_id"]
+    run_id_b = run_b_info["run_id"]
+    xls_file = run_a + '/../ctc_results/' + \
+        "CTC_Regular_v0-%s-%s.xlsm" % (run_id_a, run_id_b)
+    shutil.copyfile(xls_template, xls_file)
+    wb = load_workbook(xls_file, read_only=False, keep_vba=True)
+    this_codec = run_a_info['codec']
+    if '-' in this_codec:
+        if this_codec.split('-')[1].upper() in run_cfgs:
+            this_cfg = this_codec.split('-')[1].upper()
+    else:
+        this_cfg = 'RA'
+    anchor_sheet_name = 'Anchor-%s' % this_cfg
+    anchor_sheet = wb[anchor_sheet_name]
+    test_sheet_name = 'Test-%s' % this_cfg
+    test_sheet = wb[test_sheet_name]
+    current_video_set = run_a_info["task"]
+    if 'aomctc' in current_video_set:
+        normalized_set = current_video_set.split('-')[1].upper()
+        if normalized_set in start_rows.keys():
+            start_id = start_rows[normalized_set]
+            write_xls_rows(run_a, start_id, anchor_sheet)
+            write_xls_rows(run_b, start_id, test_sheet)
+            wb.save(xls_file)
+    else:
+        print("ERROR: Not AOM-CTC Set")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate CTC CSV version of .out files")
+    parser.add_argument("run", nargs=1, help="Run folder (Anchor)")
+    parser.add_argument("--ctc_export", action='store_true', help="XLS Export")
+    parser.add_argument(
+        "--run_b", help="Target Run Dir (Only used in CTC case)")
+    args = parser.parse_args()
+
+    if not args.ctc_export:
+        save_ctc_export(args.run[0], args)
+    else:
+        if not args.run_b:
+            print("ERROR: Missing Target, aborting")
+            sys.exit(1)
+        save_ctc_export(args.run[0], args)
+        save_ctc_export(args.run_b, args)
+
+        write_xls_file(args.run[0], args.run_b)
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/entrypoint
+++ b/etc/entrypoint
@@ -25,6 +25,9 @@ for dir in \
 	chown ${APP_USER}:${APP_USER} ${dir}
 done
 
+# CTC result storage folder
+mkdir -p "${RUNS_DST_DIR}/ctc_results"
+
 # detect main IP external address if not set/forced
 net_iface=$(awk '{ if ($2 == "00000000") { print $1; exit; } }' /proc/net/route)
 net_ip_addr=$(ip addr show dev ${net_iface} | awk -F'[ \t/]+' '/inet / { print $3; exit; }')

--- a/etc/entrypoint
+++ b/etc/entrypoint
@@ -87,6 +87,14 @@ if [ ! -d "${CODECS_SRC_DIR}/av1" ]; then
 	ln -s ${CODECS_SRC_DIR}/av1 ${CODECS_SRC_DIR}/av1-rt
 fi
 
+if [ ! -d "${CODECS_SRC_DIR}/av2" ]; then
+	gosu ${APP_USER}:${APP_USER} git clone https://gitlab.com/AOMediaCodec/avm.git ${CODECS_SRC_DIR}/av2
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ra
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ra-st
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ld
+	ln -s ${CODECS_SRC_DIR}/av2 ${CODECS_SRC_DIR}/av2-ai
+fi
+
 if [ ! -d "${CODECS_SRC_DIR}/daala" ]; then
 	gosu ${APP_USER}:${APP_USER} git clone https://github.com/xiph/daala.git ${CODECS_SRC_DIR}/daala
 fi

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -370,8 +370,15 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
     let report = this.state.report;
     if (a && b) {
       if (!report) {
+        let args = [
+          "a=" + encodeURIComponent(a.id),
+          "b=" + encodeURIComponent(b.id)
+          ];
+        let csvExportUrl = baseUrl + "ctc_report.xlsm?" + args.join("&");
         return <Panel header={"BD Rate Report"}>
-            <span className="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span> Loading report ...
+          <Button href={csvExportUrl}>Get Partial CTC Report</Button>{' '}
+          <br></br>
+          <span className="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span> Full Report loading ...
         </Panel>
       }
     } else {

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Glyphicon, Panel, Table } from "react-bootstrap";
 import { Button, FormGroup, } from "react-bootstrap";
 import { Option } from "./Widgets";
-import { BDRateReport, Report, AppStore, Job, reportFieldNames, outFileFieldNames, analyzerBaseUrl} from "../stores/Stores";
+import { BDRateReport, Report, AppStore, Job, reportFieldNames, outFileFieldNames, analyzerBaseUrl, baseUrl } from "../stores/Stores";
 
 declare var require: any;
 
@@ -410,10 +410,16 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
     interpolationOptions.push({ value: "pchip-new", label: "New interpolation method" });
     interpolationOptions.push({ value: "pchip-old", label: "Historic (AV1) interpolation method" });
     let textReport = this.state.textReport ? <pre>{this.state.textReport}</pre> : null;
+    let args = [
+      "a=" + encodeURIComponent(report.a.id),
+      "b=" + encodeURIComponent(report.b.id)
+      ];
+    let csvExportUrl = baseUrl + "ctc_report.xlsm?" + args.join("&");
       return <Panel header={`BD Rate Report ${report.a.selectedName + " " + report.a.id} → ${report.b.selectedName + " " + report.b.id}`}>
         <div style={{ paddingBottom: 8, paddingTop: 4 }}>
           <Button active={this.state.reversed} onClick={this.onReverseClick.bind(this)} >Reverse</Button>{' '}
           <Button onClick={this.onTextReportClick.bind(this)} >Get Text Report</Button>
+          <Button href={csvExportUrl} >Get CTC Report</Button>
           <FormGroup>
             <Select clearable={false} value={this.state.range} onChange={this.onChangeRange.bind(this)} options={rangeOptions} placeholder="Range">
             </Select>


### PR DESCRIPTION
This PR lays the foundations for both frontend and backend to support CTC Excel template support and also modernizes the  CSV Export to support the excel template style and lays base for creating and loading excel wb and also adding a frontend button to download the CTC template.

Good part as it is within the current report is we can easily reverse the report and can view the Text/md reports on the fly in the frontend as usual. 

Other notable changes in this PR, 
+ Add option to Partially render CTC/CSV Export 
+ Track AVM upstreams and creates run dir along other codecs 
+  The templates should be placed in config directory along other config files ie.@`conf/AOM_CWG_Regular_CTCv3_v7.2.xlsm`

<img width="888" alt="image" src="https://user-images.githubusercontent.com/10833993/188237643-9511c6e3-2dc4-42d7-a4ca-06d041a657ec.png">
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/10833993/188290937-1e2a224d-a0b1-428d-a20d-dd7ed69070d9.png">
