### PR TITLE
server/csv_export: Make sure we store selected runs into desired sheet

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -399,7 +399,7 @@ app.get('/ctc_report.xlsm', function (req, res) {
   const b = path.basename(String(req.query['b']));
   const a_file = runs_dst_dir + '/' + a;
   const b_file = runs_dst_dir + '/' + b;
-  let filename_to_send = 'CTC_Regular_v0-' + a + '-' + b + '.xlsm';
+  let filename_to_send = 'CTCv3_Regular_v7.2-' + a + '-' + b + '.xlsm';
   console.log(filename_to_send);
   console.log(runs_dst_dir)
   res.header("Content-Type", "application/vnd.ms-excel.sheet.macroEnabled.12");

--- a/csv_export.py
+++ b/csv_export.py
@@ -397,18 +397,25 @@ def write_xls_file(run_a, run_b):
     run_id_a = run_a_info["run_id"]
     run_id_b = run_b_info["run_id"]
     xls_file = run_a + '/../ctc_results/' + \
-        "CTC_Regular_v0-%s-%s.xlsm" % (run_id_a, run_id_b)
+        "CTCv3_Regular_v7.2-%s-%s.xlsm" % (run_id_a, run_id_b)
     shutil.copyfile(xls_template, xls_file)
     wb = load_workbook(xls_file, read_only=False, keep_vba=True)
-    this_codec = run_a_info['codec']
-    if '-' in this_codec:
-        if this_codec.split('-')[1].upper() in run_cfgs:
-            this_cfg = this_codec.split('-')[1].upper()
+    sheet_a_codec = run_a_info['codec']
+    sheet_b_codec = run_b_info['codec']
+    # Since we can select two presets/codecs as A/B, parse them differently,
+    if '-' in sheet_a_codec:
+        if sheet_a_codec.split('-')[1].upper() in run_cfgs:
+            this_a_cfg = sheet_a_codec.split('-')[1].upper()
     else:
-        this_cfg = 'RA'
-    anchor_sheet_name = 'Anchor-%s' % this_cfg
+        this_a_cfg = 'RA'
+    anchor_sheet_name = 'Anchor-%s' % this_a_cfg
     anchor_sheet = wb[anchor_sheet_name]
-    test_sheet_name = 'Test-%s' % this_cfg
+    if '-' in sheet_b_codec:
+        if sheet_b_codec.split('-')[1].upper() in run_cfgs:
+            this_b_cfg = sheet_b_codec.split('-')[1].upper()
+    else:
+        this_b_cfg = 'RA'
+    test_sheet_name = 'Test-%s' % this_b_cfg
     test_sheet = wb[test_sheet_name]
     current_video_set = run_a_info["task"]
     current_ctc_list_a = return_ctc_set_list(run_a_info)

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -74,14 +74,14 @@ export class App extends React.Component<{}, void> {
           <AppLogsComponent/>
         </div>
       </Tab>,
-      <Tab eventKey={8} key="status" title="Status">
+      <Tab eventKey={8} key="debug" title="Debug">
         <div style={{ padding: 10, height: height - 100, overflow: "scroll" }}>
-          <AppStatusComponent/>
+          <DebugComponent />
         </div>
       </Tab>,
-      <Tab eventKey={9} key="debug" title="Debug">
+      <Tab eventKey={9} key="status" title="AWS Status">
         <div style={{ padding: 10, height: height - 100, overflow: "scroll" }}>
-          <DebugComponent/>
+          <AppStatusComponent />
         </div>
       </Tab>,
       <Tab eventKey={10} key="login" title="Login">

--- a/www/src/components/Debug.tsx
+++ b/www/src/components/Debug.tsx
@@ -68,11 +68,11 @@ export class DebugComponent extends React.Component<{}, {
     // <Button onClick={this.onCancelJobClick.bind(this)}>Cancel Random Job</Button>{' '}
     // <Button onClick={this.onSelectJobClick.bind(this)}>Select Random Job</Button>{' '}
     return <div><Panel>
-      <Button onClick={this.onPollClick.bind(this)}>Poll Server</Button>{' '}
       <Button onClick={this.onGetRunStatus.bind(this)}>Get run_status.json</Button>{' '}
       <Button onClick={this.onGetBuildStatus.bind(this)}>Get build_status.json</Button>{' '}
-      <Button onClick={this.onGetList.bind(this)}>Get list.json</Button>{' '}
       <Button onClick={this.onMachineUsage.bind(this)}>Get machine_usage.json</Button>{' '}
+      <Button onClick={this.onGetList.bind(this)}>Get list.json</Button>{' '}
+      <Button onClick={this.onPollClick.bind(this)}>Poll Server</Button>{' '}
     </Panel>
     <pre className="pre">{this.state.log}</pre>
     </div>

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -272,7 +272,7 @@ export class SubmitJobFormComponent extends React.Component<{
       </FormGroup>
 
       <FormGroup validationState={this.getValidationState("ctcSets")}>
-        <ControlLabel>This will override default set (for CTC)</ControlLabel>
+        <ControlLabel>This will override the above set (for CTC)</ControlLabel>
         <Select multi placeholder="CTC Sets" value={this.state.ctcSets} options={ctcOptions} onChange={this.onCtcSetsSelection.bind(this)} />
       </FormGroup>
 


### PR DESCRIPTION
Users could select cross-codec/preset as A/B, that should not mean both should be written against base-codec preset, write them into actual target(LD/AI/RA).

This commit also amennds fileName to have current upstream CTC Document version.

We could see this in two ways, 
a) without this change, we could still get full CTC comparison b/w two preset-configs but in wrong title which is a way to do some comparisons too which will not be possible. 
b) With this, it writes things to appropriate sheets irrespective of codec, so if we want we can modify it from sheet to different ones,
In both cases, we get the BD-Rate and most of the analysis from the frontend.
