### PR TITLE
build_codec: use gcc/g++ for svt-av1

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -95,7 +95,7 @@ const binaries = {
   'thor': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
   'thor-rt': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
   'rav1e': ['target/release/rav1e'],
-  'svt-av1': ['Bin/Release/SvtAv1EncApp', 'Bin/Release/libSvtAv1Enc.so.0'],
+  'svt-av1': ['Bin/Release/SvtAv1EncApp'],
   'vvc-vtm': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic']
 };
 

--- a/build_codec.sh
+++ b/build_codec.sh
@@ -125,7 +125,7 @@ case "${CODEC}" in
   svt-av1)
     cd ${CODECS_SRC_DIR}/svt-av1
     cd Build/linux
-    ./build.sh --cc=gcc --cxx=g++
+    ./build.sh --cc=gcc --cxx=g++ --release --static
     ;;
 
   vvc-vtm)

--- a/build_codec.sh
+++ b/build_codec.sh
@@ -125,7 +125,7 @@ case "${CODEC}" in
   svt-av1)
     cd ${CODECS_SRC_DIR}/svt-av1
     cd Build/linux
-    ./build.sh
+    ./build.sh --cc=gcc --cxx=g++
     ;;
 
   vvc-vtm)


### PR DESCRIPTION
Probably Fixes https://github.com/xiph/awcy/issues/311
