### PR TITLE
Introduce Zipping and downloading Jobs on-demand

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -5,6 +5,7 @@ import path = require('path');
 import bodyParser = require('body-parser')
 import cookieParser = require('cookie-parser')
 import fs = require('fs-extra');
+import archiver = require('archiver');
 import cp = require('child_process');
 import irc = require('irc');
 import AWS = require('aws-sdk');
@@ -534,6 +535,46 @@ app.get('/dump_convex_hull.json',function(req,res) {
                   res.send(stdout);
                 }
               });
+});
+
+// Create API Endpoint to download the Run folder as a zip
+app.get('/download_run.zip', function (req, res) {
+  if (!req.query['a']) {
+    res.send('No Run ID specified');
+    return;
+  }
+  const run_id = path.basename(String(req.query['a']));
+  const tmp_run_zip = '/tmp/awcy_' + run_id + '.zip';
+  const output = fs.createWriteStream(tmp_run_zip);
+  const archive = archiver('zip', {
+    zlib: { level: 4 } // Sets the compression level.
+  });
+
+  // listen for all archive data to be written
+  // 'close' event is fired only when a file descriptor is involved
+  output.on('close', function () {
+    console.log(archive.pointer() + ' total bytes for ', tmp_run_zip);
+    console.log('Archiver has been finalized and the output file descriptor has closed.');
+    // Set the Headers
+    res.header("Content-Type", "application/zip");
+    res.header('Content-Disposition', 'attachment; filename="' + run_id + '.zip' + '"');
+    res.set('Content-Length', archive.pointer());
+    // Send the file
+    res.sendFile(path.resolve(tmp_run_zip));
+  });
+  // This event is fired when the data source is drained no matter what was the data source.
+  output.on('end', function () {
+    console.log('Data has been drained');
+  });
+  // good practice to catch this error explicitly
+  archive.on('error', function (err) {
+    throw err;
+  });
+  archive.pipe(output);
+  const run_folder = runs_dst_dir + '/' + run_id;
+  // Add the Run Folder to the archive
+  archive.directory(run_folder, false);
+  archive.finalize();
 });
 
 app.post('/submit/delete',function(req,res) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
     "fs-extra": "^2.0.0",
+    "archiver": "5.3.1",
     "glob": "^7.1.6",
     "irc": "^0.5.2",
     "request": "^2.88.2",

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -126,6 +126,7 @@ export class VideoReportComponent extends React.Component<VideoReportProps, {
     });
     let reportUrl = hasIvfs ? this.props.job.reportUrl(this.props.name) : this.props.job.totalReportUrl();
     let csvExportUrl = `csv_export.csv?a=${encodeURIComponent(this.props.job.id)}`;
+    let jobDownloaderUrl = `download_run.zip?a=${encodeURIComponent(this.props.job.id)}`;
     let table = <div style={{overflowX: "scroll"}}>
       <Table striped bordered condensed hover style={{width: "100%"}}>
         <thead>
@@ -140,6 +141,7 @@ export class VideoReportComponent extends React.Component<VideoReportProps, {
       <h5>Raw Data:</h5><a href={reportUrl}>{reportUrl}</a>
       <br/>
       <Button href={csvExportUrl}>CTC CSV Export</Button>
+      <Button href={jobDownloaderUrl}>Download Job (zip)</Button>
     </div>
     return table;
   }


### PR DESCRIPTION
This uses `archiver` package to compress on-demand, 

We are using Level-4 right now,, we can increase/decrease it overtime based on demand/speed/other reasons when doing via beta as the beta is not big like runners(or test server)

In the server, we are prefixing jobs with `awcy_$run_id` for easy tracking, while frontend we just have run_id for better UX.

Screenshots:
<img width="857" alt="image" src="https://user-images.githubusercontent.com/10833993/197623086-98adcf91-10d9-47b9-bfc8-e85a2696166f.png">
<img width="512" alt="image" src="https://user-images.githubusercontent.com/10833993/197623406-f4ec6ea4-c97f-4243-986e-0b97994bd43b.png">
<img width="707" alt="image" src="https://user-images.githubusercontent.com/10833993/197623848-dd821342-67b7-4143-b92e-826476866469.png">

Edit:
You can test it from VLC12 AWCY instance here: http://vlc12.xiph.osuosl.org:3000/