### PR TITLE
Pass $BUILD_OPTIONS parameter for rav1e

### DIFF
--- a/build_codec.sh
+++ b/build_codec.sh
@@ -119,7 +119,7 @@ case "${CODEC}" in
 
   rav1e)
     cd ${CODECS_SRC_DIR}/rav1e
-    cargo build --release
+    cargo build --release ${BUILD_OPTIONS}
     ;;
 
   svt-av1)


### PR DESCRIPTION
This is necessary for enabling additional Cargo features.