### PR TITLE
server: Explicitly set the http.server timeout instead of default(2mins)

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -671,7 +671,9 @@ app.post('/subjective/vote', function(req,res) {
           });
 });
 
-app.listen(config.port);
+let server = app.listen(config.port);
+server.setTimeout(600000, () => { });
+
 console.log('AWCY server started! Open a browser at http://'+external_addr+':' + config.port);
 console.log('')
 


### PR DESCRIPTION
Current nodejs version deployed v12.X have 2min timeout https://nodejs.org/docs/latest-v12.x/api/http.html#http_server_settimeout_msecs_callback

For CTC processing it takes more than that, so we require to set the timeout more than that, currently setting to 10mins which is a lot but okay for now,

Ideally we do not want such long waits, we want to split this into two, one API to initiate the geneartion, second API to send file on completition in form of second button.