### PR TITLE
awcy: Add VVC_VTM support

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -98,7 +98,11 @@ const binaries = {
   'thor-rt': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
   'rav1e': ['target/release/rav1e'],
   'svt-av1': ['Bin/Release/SvtAv1EncApp'],
-  'vvc-vtm': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic']
+  'vvc-vtm': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+  'vvc-vtm-ra': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+  'vvc-vtm-ra-st': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+  'vvc-vtm-ld': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+  'vvc-vtm-ai': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic']
 };
 
 /* The build queue. Only one job can be built at a time. */

--- a/build_codec.sh
+++ b/build_codec.sh
@@ -128,9 +128,11 @@ case "${CODEC}" in
     ./build.sh --cc=gcc --cxx=g++ --release --static
     ;;
 
-  vvc-vtm)
+  vvc-vtm*)
     cd ${CODECS_SRC_DIR}/vvc-vtm
-    cmake . -DCMAKE_BUILD_TYPE=Release
+    mkdir build
+    pushd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release
     make -j
     ;;
   *)

--- a/csv_export.py
+++ b/csv_export.py
@@ -104,6 +104,11 @@ quality_presets = {
     "thor-rt": list(range(7, 43, 3)),
     "rav1e": [20 * 4, 32 * 4, 43 * 4, 55 * 4, 63 * 4],
     "svt-av1": [20, 32, 43, 55, 63],
+    "vvc-vtm": [22, 27, 32, 37],
+    "vvc-vtm-ra": [22, 27, 32, 37],
+    "vvc-vtm-ra-st": [22, 27, 32, 37],
+    "vvc-vtm-ld": [22, 27, 32, 37],
+    "vvc-vtm-ai": [22, 27, 32, 37],
 }
 
 row_header = [

--- a/etc/entrypoint
+++ b/etc/entrypoint
@@ -109,6 +109,10 @@ fi
 
 if [ ! -d "${CODECS_SRC_DIR}/vvc-vtm" ]; then
 	gosu ${APP_USER}:${APP_USER} git clone https://vcgit.hhi.fraunhofer.de/jvet/VVCSoftware_VTM.git ${CODECS_SRC_DIR}/vvc-vtm
+	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ra
+	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ra-st
+	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ld
+	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ai
 fi
 
 if [ ! -d "${CODECS_SRC_DIR}/thor" ]; then

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -459,6 +459,8 @@ export class Job {
   ivfUrlName(name: string, quality: number) {
     if (this.codec.substring(0,3) == 'av2') {
       return `${name}-${quality}.obu`;
+    } else if (this.codec.substring(0,3) == 'vvc') {
+      return `${name}-${quality}.bin`;
     } else {
       return `${name}-${quality}.ivf`;
     }
@@ -591,7 +593,11 @@ export class Job {
     "thor": "Thor",
     "thor-rt": "Thor Realtime",
     "rav1e": "rav1e",
-    "vvc-vtm": "VVC VTM"
+    "vvc-vtm": "VVC VTM",
+    "vvc-vtm-ra": "VVC VTM Random Access (RA) GOP Parallel",
+    "vvc-vtm-ra-st": "VVC VTM Random Access (RA)",
+    "vvc-vtm-ld": "VVC VTM Low Delay (LD)",
+    "vvc-vtm-ai": "VVC VTM All Intra (AI)"
   };
 
   static sets = {};


### PR DESCRIPTION
This is dependent on the rd_tool changeset for the same set of support

Right now, we have RA, LD, AI, and also GOP Parallel. The QPs and cofigs are not fine-tuned but should be okay to have JVET_CTC as it is first.

This also unbreaks the CTC_CSV Export but XLSM will be broken due to uneven QPs