### PR TITLE
Add MD5, Perf Support and parse the values

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -21,6 +21,7 @@ RUN \
 		echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse"           >/etc/apt/sources.list && \
 		echo "deb http://security.ubuntu.com/ubuntu focal-security main restricted universe multiverse" >>/etc/apt/sources.list && \
 		echo "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse"  >>/etc/apt/sources.list; \
+		echo "deb http://security.ubuntu.com/ubuntu bionic-security main" >>/etc/apt/sources.list; \
 	else \
 		echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe multiverse"           >/etc/apt/sources.list && \
 		echo "deb http://ports.ubuntu.com/ubuntu-ports focal-security main restricted universe multiverse" >>/etc/apt/sources.list && \
@@ -64,6 +65,8 @@ RUN \
 		uuid \
 		vim \
 		wget \
+		linux-tools-$(uname -r) \
+		linux-tools-generic \
 		xz-utils && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists

--- a/bd_rate_jm.py
+++ b/bd_rate_jm.py
@@ -6,8 +6,8 @@ from numpy import *
 from scipy import *
 from scipy.interpolate import interp1d
 
-a = loadtxt(sys.argv[1])
-b = loadtxt(sys.argv[2])
+a = genfromtxt(sys.argv[1])
+b = genfromtxt(sys.argv[2])
 rates = [0.005, 0.02, 0.06, 0.2]
 ra = a[:, 2] * 8.0 / a[:, 1]
 rb = b[:, 2] * 8.0 / b[:, 1]

--- a/bd_rate_report.py
+++ b/bd_rate_report.py
@@ -270,9 +270,9 @@ error_strings = []
 
 def bdrate(file1, file2, anchorfile, fullrange):
     if anchorfile:
-        anchor = flipud(loadtxt(anchorfile))
-    a = loadtxt(file1)
-    b = loadtxt(file2)
+        anchor = flipud(genfromtxt(anchorfile))
+    a = genfromtxt(file1)
+    b = genfromtxt(file2)
     a = a[a[:, 0].argsort()]
     b = b[b[:, 0].argsort()]
     a = flipud(a)

--- a/bd_rate_report_as.py
+++ b/bd_rate_report_as.py
@@ -345,8 +345,8 @@ def bdrate_as(args, task, video, file1, file2):
         video_chres = re.sub(r"(3840x2160)", res, video)
         file1 = open(args.run[0] + "/" + task + "/" + video_chres + args.suffix)
         file2 = open(args.run[1] + "/" + task + "/" + video_chres + args.suffix)
-        a = loadtxt(file1)
-        b = loadtxt(file2)
+        a = genfromtxt(file1)
+        b = genfromtxt(file2)
         a = a[a[:, 0].argsort()]
         b = b[b[:, 0].argsort()]
         a = flipud(a)

--- a/csv_export.py
+++ b/csv_export.py
@@ -43,6 +43,10 @@ met_index = {
     "APSNR Cr (libvmaf)": 28,
     "CAMBI (libvmaf)": 29,
     "Enc MD5": 30,
+    "Enc Instr Cnt": 31,
+    "Enc Cycle Cnt": 32,
+    "Dec Instr Cnt": 33,
+    "Dec Cycle Cnt": 34,
 }
 
 # row_id for different sets inside template.
@@ -242,7 +246,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
         normalized_cfg = 'RA'
     # Get the Quality values, if user defined, use that, else do defaults
     if 'qualities' in list(info_data.keys()):
-        qp_list = info_data['qualities'].split()
+        qp_list = [int(x) for x in info_data['qualities'].split()]
     else:
         qp_list = quality_presets[info_data['codec']]
         if current_video_set in ['aomctc-f1-hires', 'aomctc-f2-midres']:
@@ -282,8 +286,20 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                     row = encoded_qp_list[this_qp]
                     frames = int(row[1]) / int(width) / int(height)
                     enc_md5 = ''
+                    enc_instr_cnt = 0
+                    enc_cycle_cnt = 0
+                    dec_instr_cnt = 0
+                    dec_cycle_cnt = 0
                     if len(row) > 33:
                         enc_md5 = str(row[met_index["Enc MD5"] + 3])
+                        enc_instr_cnt = str(
+                            row[met_index["Enc Instr Cnt"] + 3])
+                        enc_cycle_cnt = str(
+                            row[met_index["Enc Cycle Cnt"] + 3])
+                        dec_instr_cnt = str(
+                            row[met_index["Dec Instr Cnt"] + 3])
+                        dec_cycle_cnt = str(
+                            row[met_index["Dec Cycle Cnt"] + 3])
                     if info_data["codec"] in ["av2-as", "av2-as-st"]:
                         writer.writerow(
                             [
@@ -318,11 +334,11 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 row[met_index["APSNR Cr (libvmaf)"] + 3],
                                 row[met_index["Encoding Time"] + 3],
                                 row[met_index["Decoding Time"] + 3],
-                                "",  # EncInstr
-                                "",  # DecInstr
-                                "",  # EncCycles
-                                "",  # DecCycles
-                                enc_md5,  # EncMD5
+                                enc_instr_cnt,  # EncInstr
+                                dec_instr_cnt,  # DecInstr
+                                enc_cycle_cnt,  # EncCycles
+                                dec_cycle_cnt,  # DecCycles
+                                enc_md5,        # EncMD5
                             ]
                         )
                     else:
@@ -360,11 +376,11 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 row[met_index["CAMBI (libvmaf)"] + 3],
                                 row[met_index["Encoding Time"] + 3],
                                 row[met_index["Decoding Time"] + 3],
-                                "",  # ENCInstr
-                                "",  # DecInstr
-                                "",  # EncCycles
-                                "",  # DecCycles
-                                enc_md5,  # EncMD5
+                                enc_instr_cnt,  # EncInstr
+                                dec_instr_cnt,  # DecInstr
+                                enc_cycle_cnt,  # EncCycles
+                                dec_cycle_cnt,  # DecCycles
+                                enc_md5,        # EncMD5
                             ]
                         )
                 # Case where the data is yet to be made

--- a/csv_export.py
+++ b/csv_export.py
@@ -42,6 +42,7 @@ met_index = {
     "APSNR Cb (libvmaf)": 27,
     "APSNR Cr (libvmaf)": 28,
     "CAMBI (libvmaf)": 29,
+    "Enc MD5": 30,
 }
 
 # row_id for different sets inside template.
@@ -269,7 +270,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                         current_video_set,
                         video +
                         "-daala.out")
-            a = loadtxt(daala_path)
+            a = genfromtxt(daala_path, dtype=None, encoding=None)
             # This way, even partial information from the *daala.out can be
             # rendered by having key-value where key is QP.
             encoded_qp_list = {}
@@ -280,7 +281,10 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                 if this_qp in encoded_qp_list.keys():
                     row = encoded_qp_list[this_qp]
                     frames = int(row[1]) / int(width) / int(height)
-                    if info_data["codec"] in ["av2-as", "av2-as-st"] :
+                    enc_md5 = ''
+                    if len(row) > 33:
+                        enc_md5 = str(row[met_index["Enc MD5"] + 3])
+                    if info_data["codec"] in ["av2-as", "av2-as-st"]:
                         writer.writerow(
                             [
                                 "AS",  # TestCfg
@@ -318,7 +322,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 "",  # DecInstr
                                 "",  # EncCycles
                                 "",  # DecCycles
-                                "",  # EncMD5
+                                enc_md5,  # EncMD5
                             ]
                         )
                     else:
@@ -360,7 +364,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 "",  # DecInstr
                                 "",  # EncCycles
                                 "",  # DecCycles
-                                "",  # EncMD5
+                                enc_md5,  # EncMD5
                             ]
                         )
                 # Case where the data is yet to be made

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -196,10 +196,10 @@ export class SubmitJobFormComponent extends React.Component<{
         job.ctcPresets = []
       }
       // Case 2: If user has all preset, push only that, ignore rest
-      else if (this.state.ctcSets.some(checkAllPresets)) {
-        job.ctcSets = []
+      else if (this.state.ctcPresets.some(checkAllPresets)) {
+        job.ctcPresets = []
         job.codec = 'av2-ra-st';
-        job.ctcSets.push('av2-all')
+        job.ctcPresets.push('av2-all')
       }
       // Case 3: Creating/Cloning an existing job,
       // For cloning, we compare by converting to string
@@ -311,12 +311,12 @@ export class SubmitJobFormComponent extends React.Component<{
       </FormGroup>
 
       <FormGroup validationState={this.getValidationState("ctcSets")}>
-        <ControlLabel>This will override the above set (for CTC)</ControlLabel>
+        <ControlLabel>This will override the above set (for AOM-CTC)</ControlLabel>
         <Select multi placeholder="CTC Sets" value={this.state.ctcSets} options={ctcOptions} onChange={this.onCtcSetsSelection.bind(this)} />
       </FormGroup>
 
       <FormGroup validationState={this.getValidationState("ctcPresets")}>
-        <ControlLabel>This will override the above set (for CTC)</ControlLabel>
+        <ControlLabel>This will override the above preset (for AOM-CTC)</ControlLabel>
         <Select multi placeholder="CTC Presets" value={this.state.ctcPresets} options={ctcPresetOptions} onChange={this.onCtcPresetsSelection.bind(this)} />
       </FormGroup>
 


### PR DESCRIPTION
This PR adds frontend and server changes for

+ MD5Sum for EncodeJob
+ This also moves to parse the texts with help of `genfromtxt` instead of `loadtxt` as we have non-numerical entries in daala.out and for BDR computation, we ignore them. 
+ Perf Support, workers require to have them installed, and runners should have non-root support for using `perf stat`, can enable that using `sudo sh -c 'echo 1 >/proc/sys/kernel/perf_event_paranoid`, we need this for measuring,
   + Encoding, Decoding Cycles
   + Encoding, Decoding Instruction Count
+ CSV_Export: 
   + Fixes a bug in All Preset option which was parsed in wrong way where the `task` was not updated
   + Fixes a bug where custom QP was not written to CSV_file
+ Clarified frontend to be more explicit to say AOM-CTC, since we have other CTC support. 