### PR TITLE
Make 'perf' friendlier to non-Ubuntu Docker hosts

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -207,6 +207,11 @@ RUN \
     ln -s /opt/dump_ciede2000 /home/${APP_USER}/awcy_temp/dump_ciede2000 && \
     ln -s /opt/dav1d /home/${APP_USER}/awcy_temp/dav1d
 
+# substitute our modded perf script that's more Docker-friendly when the
+# host isn't a Debian/Ubuntu machine
+ADD perf /usr/bin/perf
+RUN chmod ag+x /usr/bin/perf
+
 # set entrypoint
 ADD etc/entrypoint.worker /etc/entrypoint.worker
 ENTRYPOINT [ "/etc/entrypoint.worker" ]

--- a/perf
+++ b/perf
@@ -1,0 +1,86 @@
+#!/bin/bash
+full_version=`uname -r`
+
+#Edited/modified from Debian perf wrapper, which fails badly in a
+#Docker environment with mismatched host/container distros.  We need
+#to run properly on top of RH style hosts, and the perf interfaces we
+#need will translate just fine to nearby generic linux-tool versions.
+#Be permissive in matching.
+
+# First check for a fully qualified version.
+this="/usr/lib/linux-tools/$full_version/`basename $0`"
+if [ -f "$this" ]; then
+	exec "$this" "$@"
+fi
+
+# Next, try Removing flavour from version i.e. generic or server.
+flavour_abi=${full_version#*-}
+flavour=${flavour_abi#*-}
+version=${full_version%-$flavour}
+this="$0_$version"
+if [ -f "$this" ]; then
+	exec "$this" "$@"
+fi
+
+# Next, look for generic near matches
+minor_plus=${full_version#*.}
+subminor_plus=${minor_plus#*.}
+flavor_plus=${subminor_plus#*[. -]}
+majorminor=${full_version%.$subminor_plus}
+majorminorsub=${full_version%[. -]$flavor_plus}
+
+# Check for generic version(s) matching major/minor/sub
+this=( /usr/lib/linux-tools/$majorminorsub*generic/`basename $0` )
+if [ -f "$this" ]; then
+	exec "$this" "$@"
+fi
+
+## Check for generic version(s) matching major/minor
+this=( /usr/lib/linux-tools/$majorminor*generic/`basename $0` )
+if [ -f "$this" ]; then
+	exec "$this" "$@"
+fi
+
+# back to your regularly scheduled Debian wrapper
+# Before saucy kernels we had no flavour linkage.
+if dpkg --compare-versions "$version" lt "3.11.0"; then
+	flavour=''
+else
+	flavour="-$flavour"
+fi
+# Hint at the cloud tools if they exist (trusty and later)
+if dpkg --compare-versions "$version" ge "3.13.0"; then
+	cld=""
+else
+	cld=":"
+fi
+# Work out if this is an LTS backport or not.
+codename=`lsb_release -cs`
+case "$codename" in
+precise)	base='3.2.0-9999' ;;
+trusty)		base='3.13.0-9999' ;;
+*)		base='' ;;
+esac
+std=""
+lts=":"
+if [ "$base" != "" ]; then
+	if dpkg --compare-versions "$version" gt "$base"; then
+		std=":"
+		lts=""
+	fi
+fi
+
+# Give them a hint as to what to install.
+		echo "WARNING: `basename $0` not found for kernel $version" >&2
+		echo "" >&2
+		echo "  You may need to install the following packages for this specific kernel:" >&2
+		echo "    linux-tools-$version$flavour" >&2
+$cld		echo "    linux-cloud-tools-$version$flavour" >&2
+		echo "" >&2
+		echo "  You may also want to install one of the following packages to keep up to date:" >&2
+$std		echo "    linux-tools$flavour" >&2
+$std $cld	echo "    linux-cloud-tools$flavour" >&2
+$lts		echo "    linux-tools$flavour-lts-<series>" >&2
+$lts $cld	echo "    linux-cloud-tools$flavour-lts-<series>" >&2
+
+exit 2


### PR DESCRIPTION
Debian's scripted perf wrapper does not work when run in Docker on a non Debian/Ubuntu host.  Specifically it insists on a Debian kernel and perf matching its own naming scheme, and the kernel is an impossibility on eg RH.

We don't need kernel symbols, just the userland interface, so any close 'linux-tools-*-generic' will work. Extend the script wrapper to look for these close matches, and install this extended perf when building Dockerfile.worker