### PR TITLE
www: Fix path for av2-all case in frontend and handle CTC Export correctly

### DIFF
--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -429,7 +429,11 @@ export class Job {
     if (this.ctcPresets.length > 1) {
       return baseUrl + `runs/${this.id}/${this.codec}/${this.task}/total.out`;
     } else {
-      return baseUrl + `runs/${this.id}/${this.task}/total.out`;
+      if ((this.ctcPresets.length == 1) && (this.ctcPresets[0] == 'av2-all')) {
+        return baseUrl + `runs/${this.id}/${this.codec}/${this.task}/total.out`
+      } else {
+        return baseUrl + `runs/${this.id}/${this.task}/total.out`;
+      }
     }
   }
 
@@ -437,7 +441,11 @@ export class Job {
     if (this.ctcPresets.length > 1) {
       return baseUrl + `runs/${this.id}/${this.codec}/${this.task}/${name}-daala.out`
     } else {
-      return baseUrl + `runs/${this.id}/${this.task}/${name}-daala.out`
+      if ((this.ctcPresets.length == 1) && (this.ctcPresets[0] == 'av2-all')) {
+        return baseUrl + `runs/${this.id}/${this.codec}/${this.task}/${name}-daala.out`
+      } else {
+        return baseUrl + `runs/${this.id}/${this.task}/${name}-daala.out`
+      }
     }
   }
 


### PR DESCRIPTION
Previously if we have av2-all as preset, the paths were broken.


For av2-all cases of CTC XLSM Export, numerous fixes were addressed, they are
+ QP assignment for av2-ai
+ Previously condition for folder-based config path search,
was for length is >1 when we have av2-all, it is not true, handle them
+ Make sure we revert back to Anchor/Test-* sheet names after still images,
this was a case when still images were in middle and G1/G2 was written in the still sheet,
+ Avoid re-rewriting if the config list is the same for both runs, this saves a lot of
time.
