### PR TITLE
Add VVC-VTM-AS preset and bug-fixes to csv-export

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -107,6 +107,7 @@ const binaries = {
   'vvc-vtm': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
   'vvc-vtm-ra': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
   'vvc-vtm-ra-ctc': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+  'vvc-vtm-as-ctc': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
   'vvc-vtm-ra-st': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
   'vvc-vtm-ld': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
   'vvc-vtm-ai': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic']
@@ -424,7 +425,7 @@ app.get('/ctc_report.xlsm', function (req, res) {
   const b_file = runs_dst_dir + '/' + b;
   let filename_to_send = 'AOM_CWG_Regular_CTCv3_v7.2-' + a + '-' + b + '.xlsm';
   let ctc_report_process = null;
-  if ((codec_a == 'av2-as' || codec_a == 'av2-as-st') && (codec_b == 'av2-as' || codec_b == 'av2-as-st')) {
+  if ((codec_a == 'av2-as' || codec_a == 'av2-as-st' || codec_a == 'vvc-vtm-as-ctc') && (codec_b == 'av2-as' || codec_b == 'av2-as-st' || codec_b == 'vvc-vtm-as-ctc')) {
   filename_to_send = 'AOM_CWG_AS_CTC_v9.7-' + a + '-' + b + '.xlsm';
   }
   res.header("Content-Type", "application/vnd.ms-excel.sheet.macroEnabled.12");

--- a/bd_rate_report_as.py
+++ b/bd_rate_report_as.py
@@ -381,7 +381,7 @@ try:
         print("Runs do not match.")
         sys.exit(1)
     if info_data[0]["task"] != "aomctc-a1-4k-as":
-        print("This script only works on aomctc-a2-4k-as runs.")
+        print("This script only works on aomctc-a1-4k-as runs.")
         sys.exit(1)
     task = info_data[0]["task"]
 except FileNotFoundError:

--- a/csv_export.py
+++ b/csv_export.py
@@ -67,7 +67,7 @@ start_rows = {
 }
 
 # CTC Configs
-# LD : ctc_sets_mandatory
+# LD : ctc_sets_mandatory - A1-4K
 # RA: ctc_sets_mandatory  + ctc_sets_optional
 # AI: ctc_sets_mandatory_ai + ctc_sets_optional
 # AS: A1 with Downsampling
@@ -81,6 +81,7 @@ ctc_sets_mandatory = [
     "aomctc-b2-syn"]
 ctc_sets_mandatory_ai = ctc_sets_mandatory + \
     ["aomctc-f1-hires", "aomctc-f2-midres"]
+ctc_sets_mandatory_ld = [x for x in ctc_sets_mandatory if x != 'aomctc-a1-4k']
 ctc_sets_optional = ["aomctc-g1-hdr-4k",
                      "aomctc-g2-hdr-2k", "aomctc-e-nonpristine"]
 
@@ -207,13 +208,15 @@ def return_ctc_set_list(run_info, config):
             elif config == 'av2-ra-st' or config == 'av2-ra':
                 run_set_list = ctc_sets_mandatory + ctc_sets_optional
             elif config == 'av2-ld':
-                run_set_list = ctc_sets_mandatory
+                run_set_list = ctc_sets_mandatory_ld
             else:
                 run_set_list = [run_info['task']]
         elif 'aomctc-mandatory' in set_name and ('av2' in config or 'vvc' in config):
             if config in ['av2-ra-st', 'av2-ra', 'vvc-vtm',
                           'vvc-vtm-ra', 'vvc-vtm-ra-ctc', 'vvc-vtm-as-ctc', 'vvc-vtm-ra-st', 'vvc-vtm-ld']:
                 run_set_list = ctc_sets_mandatory
+            elif config in ['av2-ld', 'vvc-ra-ld']:
+                run_set_list = ctc_sets_mandatory_ld
             elif config in ['av2-ai', 'vvc-vtm-ai']:
                 run_set_list = ctc_sets_mandatory_ai
             else:

--- a/csv_export.py
+++ b/csv_export.py
@@ -561,7 +561,10 @@ def write_xls_cfg_sheet(run_a, run_b, run_cfg_list,
                     anchor_sheet_name = 'Anchor-Still'
                     anchor_sheet = wb[anchor_sheet_name]
                 else:
-                    anchor_sheet_name = 'Anchor-%s' % this_cfg
+                    if this_cfg == 'AS':
+                        anchor_sheet_name = 'Anchor'
+                    else:
+                        anchor_sheet_name = 'Anchor-%s' % this_cfg
                     anchor_sheet = wb[anchor_sheet_name]
                 write_xls_rows(run_a, this_video_set, this_cfg, anchor_sheet)
             for this_video_set in current_ctc_list_b:
@@ -580,7 +583,10 @@ def write_xls_cfg_sheet(run_a, run_b, run_cfg_list,
                     test_sheet_name = 'Test-Still'
                     test_sheet = wb[test_sheet_name]
                 else:
-                    test_sheet_name = 'Test-%s' % this_cfg
+                    if this_cfg == 'AS':
+                        test_sheet_name = 'Test'
+                    else:
+                        test_sheet_name = 'Test-%s' % this_cfg
                     test_sheet = wb[test_sheet_name]
                 write_xls_rows(run_b, this_video_set, this_cfg, test_sheet)
             wb.save(xls_file)

--- a/csv_export.py
+++ b/csv_export.py
@@ -331,13 +331,13 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                     dec_cycle_cnt = 0
                     if len(row) > 33:
                         enc_md5 = str(row[met_index["Enc MD5"] + 3])
-                        enc_instr_cnt = str(
+                        enc_instr_cnt = int(
                             row[met_index["Enc Instr Cnt"] + 3])
-                        enc_cycle_cnt = str(
+                        enc_cycle_cnt = int(
                             row[met_index["Enc Cycle Cnt"] + 3])
-                        dec_instr_cnt = str(
+                        dec_instr_cnt = int(
                             row[met_index["Dec Instr Cnt"] + 3])
-                        dec_cycle_cnt = str(
+                        dec_cycle_cnt = int(
                             row[met_index["Dec Cycle Cnt"] + 3])
                     if info_data["codec"] in [
                             "av2-as", "av2-as-st", 'vvc-vtm-as-ctc']:
@@ -374,10 +374,10 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 row[met_index["APSNR Cr (libvmaf)"] + 3],
                                 row[met_index["Encoding Time"] + 3],
                                 row[met_index["Decoding Time"] + 3],
-                                enc_instr_cnt,  # EncInstr
-                                dec_instr_cnt,  # DecInstr
-                                enc_cycle_cnt,  # EncCycles
-                                dec_cycle_cnt,  # DecCycles
+                                int(enc_instr_cnt),  # EncInstr
+                                int(dec_instr_cnt),  # DecInstr
+                                int(enc_cycle_cnt),  # EncCycles
+                                int(dec_cycle_cnt),  # DecCycles
                                 enc_md5,        # EncMD5
                             ]
                         )
@@ -416,10 +416,10 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 row[met_index["CAMBI (libvmaf)"] + 3],
                                 row[met_index["Encoding Time"] + 3],
                                 row[met_index["Decoding Time"] + 3],
-                                enc_instr_cnt,  # EncInstr
-                                dec_instr_cnt,  # DecInstr
-                                enc_cycle_cnt,  # EncCycles
-                                dec_cycle_cnt,  # DecCycles
+                                int(enc_instr_cnt),  # EncInstr
+                                int(dec_instr_cnt),  # DecInstr
+                                int(enc_cycle_cnt),  # EncCycles
+                                int(dec_cycle_cnt),  # DecCycles
                                 enc_md5,        # EncMD5
                             ]
                         )
@@ -484,7 +484,9 @@ def save_ctc_export(run_path, cmd_args):
 def write_xls_rows(run_path, current_video_set, current_config, this_sheet):
     run_file = open(run_path + '/csv_export.csv', 'r')
     start_id, normalized_set = return_start_rows(current_video_set)
-
+    row_end_idx = 31
+    if current_config == 'AS':
+        row_end_idx = 30
     run_reader = csv.reader(run_file)
     next(run_reader)
     this_row = start_id
@@ -495,7 +497,8 @@ def write_xls_rows(run_path, current_video_set, current_config, this_sheet):
             this_col = 1
             for this_values in this_line:
                 this_cell = this_sheet.cell(row=this_row, column=this_col)
-                if this_col >= 12 and this_col <= 30 and this_values != "":
+                # QP_val:perf_stats
+                if this_col >= 11 and this_col <= row_end_idx and this_values != "":
                     this_cell.value = float(this_values)
                 else:
                     this_cell.value = this_values

--- a/csv_export.py
+++ b/csv_export.py
@@ -324,6 +324,12 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                 if this_qp in encoded_qp_list.keys():
                     row = encoded_qp_list[this_qp]
                     frames = int(row[1]) / int(width) / int(height)
+                    # For still-images set compute Bytes
+                    if normalized_set in ['F1', 'F2']:
+                        enc_bitrate = round(int(row[2]) * 8.0, 6)
+                    else:
+                        enc_bitrate = round(
+                            int(row[2]) * 8.0 * float(fps_n) / float(fps_d) / frames / 1000.0, 6)
                     enc_md5 = ''
                     enc_instr_cnt = 0
                     enc_cycle_cnt = 0
@@ -354,12 +360,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 10,  # BitDepth
                                 str(width) + "x" + str(height),  # CodedRes
                                 row[0],  # qp
-                                int(row[2])
-                                * 8.0
-                                * float(fps_n)
-                                / float(fps_d)
-                                / frames
-                                / 1000.0,  # bitrate
+                                enc_bitrate,  # bitrate
                                 row[met_index["PSNR Y (libvmaf)"] + 3],
                                 row[met_index["PSNR Cb (libvmaf)"] + 3],
                                 row[met_index["PSNR Cr (libvmaf)"] + 3],
@@ -395,12 +396,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                                 10,  # BitDepth #TODO: FIXME
                                 str(width) + "x" + str(height),  # CodedRes
                                 int(row[0]),  # qp
-                                int(row[2])
-                                * 8.0
-                                * float(fps_n)
-                                / float(fps_d)
-                                / frames
-                                / 1000.0,  # bitrate
+                                enc_bitrate,  # bitrate
                                 row[met_index["PSNR Y (libvmaf)"] + 3],
                                 row[met_index["PSNR Cb (libvmaf)"] + 3],
                                 row[met_index["PSNR Cr (libvmaf)"] + 3],

--- a/csv_export.py
+++ b/csv_export.py
@@ -119,6 +119,7 @@ quality_presets = {
     "vvc-vtm": [22, 27, 32, 37],
     "vvc-vtm-ra": [22, 27, 32, 37],
     "vvc-vtm-ra-ctc": [22, 27, 32, 37, 42, 47],
+    "vvc-vtm-as-ctc": [22, 27, 32, 37, 42, 47],
     "vvc-vtm-ra-st": [22, 27, 32, 37],
     "vvc-vtm-ld": [22, 27, 32, 37],
     "vvc-vtm-ai": [22, 27, 32, 37],
@@ -210,8 +211,8 @@ def return_ctc_set_list(run_info, config):
             else:
                 run_set_list = [run_info['task']]
         elif 'aomctc-mandatory' in set_name and ('av2' in config or 'vvc' in config):
-            if config in ['av2-ra-st', 'av2-ra', 'av2-ld', 'vvc-vtm',
-                          'vvc-vtm-ra', 'vvc-vtm-ra-ctc', 'vvc-ra-st', 'vvc-ra-ld']:
+            if config in ['av2-ra-st', 'av2-ra', 'vvc-vtm',
+                          'vvc-vtm-ra', 'vvc-vtm-ra-ctc', 'vvc-vtm-as-ctc', 'vvc-vtm-ra-st', 'vvc-vtm-ld']:
                 run_set_list = ctc_sets_mandatory
             elif config in ['av2-ai', 'vvc-vtm-ai']:
                 run_set_list = ctc_sets_mandatory_ai
@@ -246,6 +247,10 @@ def return_config(this_config):
     if 'av2-' in this_config:
         if this_config.split('-')[1].upper() in run_cfgs:
             this_cfg = this_config.split('-')[1].upper()
+    # VVC has VVC-VTM-* style of naming presets!
+    elif 'vvc-' in this_config:
+        if this_config.split('-')[2].upper() in run_cfgs:
+            this_cfg = this_config.split('-')[2].upper()
     else:
         this_cfg = 'RA'
     return this_cfg
@@ -331,7 +336,8 @@ def write_set_data(run_path, writer, current_video_set, current_config):
                             row[met_index["Dec Instr Cnt"] + 3])
                         dec_cycle_cnt = str(
                             row[met_index["Dec Cycle Cnt"] + 3])
-                    if info_data["codec"] in ["av2-as", "av2-as-st"]:
+                    if info_data["codec"] in [
+                            "av2-as", "av2-as-st", 'vvc-vtm-as-ctc']:
                         writer.writerow(
                             [
                                 "AS",  # TestCfg
@@ -458,7 +464,7 @@ def save_ctc_export(run_path, cmd_args):
     else:
         csv_writer_obj = open(run_path + "/csv_export.csv", 'w')
     w = csv.writer(csv_writer_obj, dialect="excel")
-    if cfg_name == ['av1-as', 'av2-as-st']:
+    if cfg_name in ['av2-as', 'av2-as-st', 'vvc-vtm-as-ctc']:
         w.writerow(row_header_as)
     else:
         w.writerow(row_header)

--- a/csv_export.py
+++ b/csv_export.py
@@ -269,7 +269,7 @@ def write_set_data(run_path, writer, current_video_set, current_config):
     videos = sets[current_video_set]["sources"]
     # sort name ascending, resolution descending
     if current_video_set != "aomctc-a1-4k-as":
-        videos.sort(key=lambda s: s.lower())
+        videos.sort()
     else:
         videos.sort(
             key=lambda x: x.split("_")[0]
@@ -452,7 +452,7 @@ def save_ctc_export(run_path, cmd_args):
     videos = sets[task]["sources"]
     # sort name ascending, resolution descending
     if task != "aomctc-a1-4k-as":
-        videos.sort(key=lambda s: s.lower())
+        videos.sort()
     else:
         videos.sort(
             key=lambda x: x.split("_")[0]

--- a/etc/entrypoint
+++ b/etc/entrypoint
@@ -117,6 +117,7 @@ if [ ! -d "${CODECS_SRC_DIR}/vvc-vtm" ]; then
 	gosu ${APP_USER}:${APP_USER} git clone https://vcgit.hhi.fraunhofer.de/jvet/VVCSoftware_VTM.git ${CODECS_SRC_DIR}/vvc-vtm
 	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ra
 	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ra-ctc
+	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-as-ctc
 	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ra-st
 	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ld
 	ln -s ${CODECS_SRC_DIR}/vvc-vtm ${CODECS_SRC_DIR}/vvc-vtm-ai

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -418,7 +418,7 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
             top: 4,
             fontFamily: "'Roboto Mono',monospace",
             fontSize: 12,
-          }}>
+          }} open>
             <summary className="Select-control" style={{
               paddingBottom: 8,
               paddingTop: 6, paddingLeft: 8
@@ -485,7 +485,7 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
               top: 4,
               fontFamily: "'Roboto Mono',monospace",
               fontSize: 12,
-            }}>
+            }} open>
               <summary className="Select-control" style={{
                 paddingBottom: 8,
                 paddingTop: 6, paddingLeft: 8

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -610,6 +610,7 @@ export class Job {
     "vvc-vtm": "VVC VTM",
     "vvc-vtm-ra": "VVC VTM Random Access (RA) GOP Parallel",
     "vvc-vtm-ra-ctc": "VVC VTM AOM Random Access (RA) GOP Parallel",
+    "vvc-vtm-as-ctc": "VVC VTM AOM Adaptive Streaming (AS) GOP Parallel",
     "vvc-vtm-ra-st": "VVC VTM Random Access (RA)",
     "vvc-vtm-ld": "VVC VTM Low Delay (LD)",
     "vvc-vtm-ai": "VVC VTM All Intra (AI)"


### PR DESCRIPTION
This patchset enables AS preset for VVC along with various bug fixes to CSV_Export,
+ Do not lower-case when writing
  This creates a problem for Class E where two sequences were flipped
+ Explicit cast of perf-stat when writing to CSV/XLSM file
  This avoids treating the last col as Text
+ Do not write A1-4K for LD
+ Write VVC-VTM AS config


Depends on https://github.com/xiph/rd_tool/pull/145