### PR TITLE
build: Restrict VVC builds to 8 cores and improve frontend polling

### DIFF
--- a/build_codec.sh
+++ b/build_codec.sh
@@ -133,7 +133,7 @@ case "${CODEC}" in
     mkdir build
     pushd build
     cmake .. -DCMAKE_BUILD_TYPE=Release
-    make -j
+    make -j 8
     ;;
   *)
     echo "Unknown codec '${CODEC}'" >&2

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -377,7 +377,7 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
     }
     this.logInterval = setInterval(() => {
       this.loadCtcLog(true);
-    }, 5000);
+    }, 2500);
   }
 
   loadCtcLog(refresh = false): Promise<string> {


### PR DESCRIPTION
This is to save RAM