### PR TITLE
Job tracker improvements

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -492,6 +492,9 @@ app.post('/submit/job',function(req,res) {
   } else {
     req.body.ctcPresets = req.body.ctcPresets.split(',')
   }
+  if (!req.body.date) {
+    req.body.date = new Date(Date.now());
+  }
   const job = {
     'codec': req.body.codec,
     'commit': req.body.commit,
@@ -508,6 +511,7 @@ app.post('/submit/job',function(req,res) {
     'arch': req.body.arch,
     'ctcSets': req.body.ctcSets,
     'ctcPresets': req.body.ctcPresets,
+    'submit_time': req.body.date,
   }
 
   const gerrit_detect_re = /I[0-9a-f]{40}/g;

--- a/www/src/components/Job.tsx
+++ b/www/src/components/Job.tsx
@@ -118,7 +118,13 @@ export class JobComponent extends React.Component<JobProps, {
     //     hasReport = <div className="jobWarning">Report failed to build or is not yet available.</div>
     //   }
     // }
-    let date = job.date ? `${timeSince(job.date)}`: "";
+    // This is a new field in the info.json which stores the submission time.
+    job.submit_time = new Date(job.submit_time);
+    // Making this backward compatible for old jobs without submit_time metadata
+    if (isNaN(job.submit_time.valueOf())) {
+      job.submit_time = new Date(job.date);
+    }
+    let date = job.submit_time ? `${timeSince(job.submit_time)}` : "";
 
     let borderRight = job.selected ? "4px solid " + job.color : undefined;
     let borderLeft = borderRight;

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -369,6 +369,7 @@ export class Job {
   arch: string = "x86_64";
   ctcSets: string[] = [];
   ctcPresets: string[] = [];
+  submit_time: Date;
 
   progress: JobProgress = new JobProgress(0, 0);
   selected: boolean = false;
@@ -573,6 +574,7 @@ export class Job {
     job.arch = json.arch || "x86_64";
     job.ctcSets = json.ctcSets || "";
     job.ctcPresets = json.ctcPresets || "";
+    job.submit_time = json.submit_time || "";
 
     job.saveEncodedFiles = parseBoolean(json.save_encode);
     job.runABCompare = parseBoolean(json.ab_compare);

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -965,8 +965,10 @@ export class AppStore {
             job.status = JobStatus.Running;
             console.log("detected zombie job:",o.run_id);
           }
-          job.progress.value = o.completed;
-          job.progress.total = o.total;
+          // Migrate to use multi_completed/total as we can have more than 1
+          // task and configuration (for eg. AOM-CTC config combinations)
+          job.progress.value = o.multi_completed;
+          job.progress.total = o.multi_total;
           job.loadLog(true);
           job.onChange.post("updated status");
         });


### PR DESCRIPTION
Two main things

a) Improve the submission job tracker, if we do not store the job-submission time, we will be replacing the value with the newly finished job from the multi-set/config queue. 
So we can start saving the submission time to info.json
For backward compatibility, if the information is not there, "date" information is used as "submit_time".


b) Improve the running job counter, this relies on the rd_tool patchset(backend) https://github.com/xiph/rd_tool/pull/147, where for a given job we introduce a multi-job tracker. 