### PR TITLE
awcy: replace all spaces in run name with _

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -496,7 +496,7 @@ app.post('/submit/job',function(req,res) {
     'codec': req.body.codec,
     'commit': req.body.commit,
     'nick': req.body.nick,
-    'run_id': req.body.run_id.replace(' ','_'),
+    'run_id': req.body.run_id.replace(/\s/g,'_'),
     'task': req.body.task,
     'extra_options': req.body.extra_options,
     'build_options': req.body.build_options,


### PR DESCRIPTION
Before this change, only the first was being replaced. Fixes #27 and #197.