### PR TITLE
awcy: Migrate to CTC-V4

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -423,7 +423,7 @@ app.get('/ctc_report.xlsm', function (req, res) {
   const codec_b = path.basename(String(req.query['codec_b']))
   const a_file = runs_dst_dir + '/' + a;
   const b_file = runs_dst_dir + '/' + b;
-  let filename_to_send = 'AOM_CWG_Regular_CTCv3_v7.2-' + a + '-' + b + '.xlsm';
+  let filename_to_send = 'AOM_CWG_Regular_CTCv4_v7.3.2-' + a + '-' + b + '.xlsm';
   let ctc_report_process = null;
   if ((codec_a == 'av2-as' || codec_a == 'av2-as-st' || codec_a == 'vvc-vtm-as-ctc') && (codec_b == 'av2-as' || codec_b == 'av2-as-st' || codec_b == 'vvc-vtm-as-ctc')) {
   filename_to_send = 'AOM_CWG_AS_CTC_v9.7-' + a + '-' + b + '.xlsm';

--- a/csv_export.py
+++ b/csv_export.py
@@ -597,7 +597,7 @@ def write_xls_file(run_a, run_b):
     run_b_info = json.load(open(run_b + "/info.json"))
     run_id_a = run_a_info["run_id"]
     run_id_b = run_b_info["run_id"]
-    xls_filename = 'AOM_CWG_Regular_CTCv3_v7.2'
+    xls_filename = 'AOM_CWG_Regular_CTCv4_v7.3.2'
     if run_a_info["task"] == 'aomctc-a1-4k-as':
         xls_filename = 'AOM_CWG_AS_CTC_v9.7'
     xls_template = os.path.join(

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -385,7 +385,7 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
       if (this.ctc_xls_logs && !refresh) {
         return Promise.resolve(this.ctc_xls_logs);
       }
-      let filename_to_send = 'AOM_CWG_Regular_CTCv3_v7.2-' + this.props.a.id + '-' + this.props.b.id + '.txt';
+      let filename_to_send = 'AOM_CWG_Regular_CTCv4_v7.3.2-' + this.props.a.id + '-' + this.props.b.id + '.txt';
       let path = baseUrl + 'runs/ctc_results/' + filename_to_send;
       return loadXHR2<string>(path, "text").then((log) => {
         this.ctc_xls_logs = log;


### PR DESCRIPTION
Weirdly CTCv4 have a new filename for Regular, and not for AS, but it is how it is.

Maybe we need to think of migrating this to a new environment variable to reduce the noise in the repo if the updates are too frequent. 
