### PR TITLE
Deprecate sorting and add GOP-Parallel to CTC grid

### DIFF
--- a/csv_export.py
+++ b/csv_export.py
@@ -268,13 +268,15 @@ def write_set_data(run_path, writer, current_video_set, current_config):
         open(os.path.join(os.getenv("CONFIG_DIR", "rd_tool"), "sets.json")))
     videos = sets[current_video_set]["sources"]
     # sort name ascending, resolution descending
-    if current_video_set != "aomctc-a1-4k-as":
-        videos.sort()
-    else:
+    if current_video_set == "aomctc-a1-4k-as":
         videos.sort(
             key=lambda x: x.split("_")[0]
             + "%08d" % (100000 - int(x.split("_")[1].split("x")[0]))
         )
+    # Case of normal CTC clips apart from AS,
+    # Deprecrate sorting for CTC reasons now!!
+    else:
+        pass
     if 'av2' in info_data['codec']:
         normalized_cfg = info_data['codec'].split('-')[1].upper()
     else:
@@ -447,13 +449,16 @@ def save_ctc_export(run_path, cmd_args):
         open(os.path.join(os.getenv("CONFIG_DIR", "rd_tool"), "sets.json")))
     videos = sets[task]["sources"]
     # sort name ascending, resolution descending
-    if task != "aomctc-a1-4k-as":
-        videos.sort()
-    else:
+    if task == "aomctc-a1-4k-as":
         videos.sort(
             key=lambda x: x.split("_")[0]
             + "%08d" % (100000 - int(x.split("_")[1].split("x")[0]))
         )
+    # Case of normal CTC clips apart from AS,
+    # Deprecrate sorting for CTC reasons now!!
+    else:
+        pass
+
     ctc_set_list = return_ctc_set_list(info_data, info_data['codec'])
     ctc_cfg_list = return_ctc_cfg_list(info_data)
     cfg_name = info_data['codec']

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -258,7 +258,7 @@ export class SubmitJobFormComponent extends React.Component<{
     const archOptions = [{value: 'x86_64', label: 'x86_64'}, {value: 'aarch64', label: 'aarch64'}];
     // CTC: Create a user-friendly CTC set list.
     const ctcOptions = [{ value: 'aomctc-a1-4k', label: 'A1' }, { value: 'aomctc-a2-2k', label: 'A2' }, { value: 'aomctc-a3-720p', label: 'A3' }, { value: 'aomctc-a4-360p', label: 'A4' }, { value: 'aomctc-a5-270p', label: 'A5' }, { value: 'aomctc-b1-syn', label: 'B1' }, { value: 'aomctc-b2-syn', label: 'B2' }, { value: 'aomctc-f1-hires', label: 'F1' }, { value: 'aomctc-f2-midres', label: 'F2' }, { value: 'aomctc-g1-hdr-4k', label: 'G1' }, { value: 'aomctc-g2-hdr-2k', label: 'G2' }, { value: 'aomctc-e-nonpristine', label: 'E' }, { value: 'aomctc-all', label: 'All' }, { value: 'aomctc-mandatory', label: 'Mandatory' }];
-    const ctcPresetOptions = [{ value: 'av2-ra-st', label: 'RA' }, { value: 'av2-ai', label: 'AI' }, { value: 'av2-ld', label: 'LD' }, { value: 'av2-all', label: 'All' }];
+    const ctcPresetOptions = [{ value: 'av2-ra-st', label: 'RA' }, { value: 'av2-ra', label: 'RA (GOP parallel)' }, { value: 'av2-ai', label: 'AI' }, { value: 'av2-ld', label: 'LD' }, { value: 'av2-all', label: 'All' }];
 
     return <Form>
       <FormGroup validationState={this.getValidationState("id")}>


### PR DESCRIPTION
This set is made of two parts,

Part A:
CTC now reached a stage where the clipList is of different styles like,
a) CLIPNAME, b) ClipName, c) clipName, d) clipname, e) Clip_name, and
many other variants of stying for sequences name.
Handling all of them is now impossible without modifying clip names.
So let's trust and do the hardcoding of the clip in the exact order we want.


Part B:
We also add RA-GOP parallel to UI
<img width="338" alt="image" src="https://github.com/xiph/awcy/assets/10833993/f21d8fa0-6dc7-44e7-a2ea-ee60fb5644bb">

