### PR TITLE
bd_rate: Compute BD-Rate between Sequential and Parallel runs

### DIFF
--- a/bd_rate_report.py
+++ b/bd_rate_report.py
@@ -378,6 +378,8 @@ try:
         sys.exit(1)
     task = info_data[0]["task"]
     codec = info_data[0]["codec"]
+    codec_a = info_data[0]["codec"]
+    codec_b = info_data[1]["codec"]
 except FileNotFoundError:
     # no info.json, using bare directories
     print("Couldn't open", args.run[0])
@@ -408,10 +410,10 @@ if info_data:
         run_b = args.run[1] + "/" + task + "/" + video + args.suffix
         if 'ctcPresets' in info_data[0].keys():
             if len(info_data[0]["ctcPresets"]) > 1 or 'av2-all' in info_data[0]["ctcPresets"]:
-                run_a = args.run[0] + "/" + codec + "/" + task + "/" + video + args.suffix
+                run_a = args.run[0] + "/" + codec_a + "/" + task + "/" + video + args.suffix
         if 'ctcPresets' in info_data[1].keys():
             if len(info_data[1]["ctcPresets"]) > 1 or 'av2-all' in info_data[1]["ctcPresets"]:
-                run_b = args.run[1] + "/" + codec + "/" + task + "/" + video + args.suffix
+                run_b = args.run[1] + "/" + codec_b + "/" + task + "/" + video + args.suffix
         if args.overlap:
             metric_data[video] = bdrate(
                 run_a,


### PR DESCRIPTION
This was found to be missing in the CTC file-path handling, this enables bdr computation for non-parallel GOP and parallel GOP runs.

Eg, `av2-ra` and `av2-ra-st` is problematic in the current master,

```python
Traceback (most recent call last):
  File "./bd_rate_report.py", line 420, in <module>
    args.fullrange,
  File "./bd_rate_report.py", line 275, in bdrate
    b = genfromtxt(file2)
  File "/home/awcybeta/.local/lib/python3.6/site-packages/numpy/lib/npyio.py", line 1749, in genfromtxt
    fid = np.lib._datasource.open(fname, 'rt', encoding=encoding)
  File "/home/awcybeta/.local/lib/python3.6/site-packages/numpy/lib/_datasource.py", line 195, in open
    return ds.open(path, mode, encoding=encoding, newline=newline)
  File "/home/awcybeta/.local/lib/python3.6/site-packages/numpy/lib/_datasource.py", line 535, in open
    raise IOError("%s not found." % path)
OSError: /home/awcybeta/awcy/runs/AVM-Research-v4.0.0-Regular-All-CTCv4/av2-ra/aomctc-a2-2k/Aerial3200_1920x1080_5994_10bit_420.y4m-daala.out not found.
```


Edit: This is only applicable to AOM-CTC runs
