### PR TITLE
AOM: Introduce CTC version toggle and add support to CTCv5.0 in XLSM export

### DIFF
--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -492,6 +492,9 @@ app.post('/submit/job',function(req,res) {
   } else {
     req.body.ctcPresets = req.body.ctcPresets.split(',')
   }
+  if (!req.body.ctcVersion) {
+    req.body.ctcVersion = "5.0"
+  }
   if (!req.body.date) {
     req.body.date = new Date(Date.now());
   }
@@ -511,6 +514,7 @@ app.post('/submit/job',function(req,res) {
     'arch': req.body.arch,
     'ctcSets': req.body.ctcSets,
     'ctcPresets': req.body.ctcPresets,
+    'ctcVersion': req.body.ctcVersion,
     'submit_time': req.body.date,
   }
 

--- a/awcy_server.ts
+++ b/awcy_server.ts
@@ -421,13 +421,27 @@ app.get('/ctc_report.xlsm', function (req, res) {
   const b = path.basename(String(req.query['b']));
   const codec_a = path.basename(String(req.query['codec_a']))
   const codec_b = path.basename(String(req.query['codec_b']))
+  const ctcVersion_a = path.basename(String(req.query['ctcVersion_a']))
+  const ctcVersion_b = path.basename(String(req.query['ctcVersion_b']))
+  let ctcVersion_target = "5.0";
+  let ctc_as_flag = false;
+  if ((codec_a == 'av2-as' || codec_a == 'av2-as-st' || codec_a == 'vvc-vtm-as-ctc') && (codec_b == 'av2-as' || codec_b == 'av2-as-st' || codec_b == 'vvc-vtm-as-ctc')) {
+    ctc_as_flag = true;
+  }
   const a_file = runs_dst_dir + '/' + a;
   const b_file = runs_dst_dir + '/' + b;
-  let filename_to_send = 'AOM_CWG_Regular_CTCv4_v7.3.2-' + a + '-' + b + '.xlsm';
-  let ctc_report_process = null;
-  if ((codec_a == 'av2-as' || codec_a == 'av2-as-st' || codec_a == 'vvc-vtm-as-ctc') && (codec_b == 'av2-as' || codec_b == 'av2-as-st' || codec_b == 'vvc-vtm-as-ctc')) {
-  filename_to_send = 'AOM_CWG_AS_CTC_v9.7-' + a + '-' + b + '.xlsm';
+  let ctc_xlsm = 'AOM_CWG_Regular_CTCv4_v7.3.2-';
+  if (ctc_as_flag == true)
+    ctc_xlsm = 'AOM_CWG_AS_CTC_v9.7-';
+  if ((ctcVersion_a == ctcVersion_target) || (ctcVersion_b == ctcVersion_target)) {
+    ctc_xlsm = 'AOM_CWG_Regular_CTCv5_v7.4.5-';
+    if (ctc_as_flag == true)
+      ctc_xlsm = 'AOM_CWG_AS_CTC_v9.9-';
   }
+
+  let filename_to_send = ctc_xlsm + a + '-' + b + '.xlsm';
+  let ctc_report_process = null;
+
   res.header("Content-Type", "application/vnd.ms-excel.sheet.macroEnabled.12");
   res.header('Content-Disposition', 'attachment; filename="' + filename_to_send + '"');
   const env = { ...process.env };

--- a/www/src/components/Job.tsx
+++ b/www/src/components/Job.tsx
@@ -155,6 +155,7 @@ export class JobComponent extends React.Component<JobProps, {
       details.push(keyValue("Save Encoded Files", job.saveEncodedFiles));
       if (job.ctcSets) details.push(keyValue("CTC Sets", JSON.stringify(job.ctcSets)));
       if (job.ctcPresets) details.push(keyValue("CTC Presets", JSON.stringify(job.ctcPresets)));
+      if (job.ctcVersion) details.push(keyValue("CTC Version", job.ctcVersion));
       details.push(keyValue("Status", JobStatus[job.status]));
     }
     let award = null;

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -382,10 +382,27 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
 
   loadCtcLog(refresh = false): Promise<string> {
     if (this.props.a && this.props.b) {
+      let codec_a = this.props.a.codec;
+      let codec_b = this.props.b.codec;
+      let ctcVersion_a = this.props.a.ctcVersion;
+      let ctcVersion_b = this.props.b.ctcVersion;
+      let ctcVersion_target = "5.0";
+      let ctc_as_flag = false;
+      if ((codec_a == 'av2-as' || codec_a == 'av2-as-st' || codec_a == 'vvc-vtm-as-ctc') && (codec_b == 'av2-as' || codec_b == 'av2-as-st' || codec_b == 'vvc-vtm-as-ctc')) {
+        ctc_as_flag = true;
+      }
       if (this.ctc_xls_logs && !refresh) {
         return Promise.resolve(this.ctc_xls_logs);
       }
-      let filename_to_send = 'AOM_CWG_Regular_CTCv4_v7.3.2-' + this.props.a.id + '-' + this.props.b.id + '.txt';
+      let ctc_xlsm = 'AOM_CWG_Regular_CTCv4_v7.3.2-';
+      if (ctc_as_flag == true)
+        ctc_xlsm = 'AOM_CWG_AS_CTC_v9.7-';
+      if (ctcVersion_a == ctcVersion_target || ctcVersion_b == ctcVersion_target) {
+        ctc_xlsm = 'AOM_CWG_Regular_CTCv5_v7.4.5-';
+        if (ctc_as_flag == true)
+          ctc_xlsm = 'AOM_CWG_AS_CTC_v9.9-';
+      }
+      let filename_to_send = ctc_xlsm + this.props.a.id + '-' + this.props.b.id + '.txt';
       let path = baseUrl + 'runs/ctc_results/' + filename_to_send;
       return loadXHR2<string>(path, "text").then((log) => {
         this.ctc_xls_logs = log;
@@ -406,7 +423,9 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
           "a=" + encodeURIComponent(a.id),
           "b=" + encodeURIComponent(b.id),
           "codec_a="+ encodeURIComponent(a.codec),
-          "codec_b="+ encodeURIComponent(b.codec)
+          "codec_b="+ encodeURIComponent(b.codec),
+          "ctcVersion_a="+ encodeURIComponent(a.ctcVersion),
+          "ctcVersion_b="+ encodeURIComponent(b.ctcVersion)
           ];
         let csvExportUrl = baseUrl + "ctc_report.xlsm?" + args.join("&");
         return <Panel header={"BD Rate Report"}>

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -17,6 +17,7 @@ export class SubmitJobFormComponent extends React.Component<{
     arch: Option;
     ctcSets: Option[];
     ctcPresets: Option[];
+    ctcVersion: Option;
   }> {
   constructor() {
     super();
@@ -40,6 +41,7 @@ export class SubmitJobFormComponent extends React.Component<{
       job.arch = template.arch;
       job.ctcSets = template.ctcSets;
       job.ctcPresets = template.ctcPresets;
+      job.ctcVersion = template.ctcVersion;
     }
     let task = job.task ? job.task : "objective-1-fast";
     let codec = job.codec ? job.codec : "av1";
@@ -52,6 +54,7 @@ export class SubmitJobFormComponent extends React.Component<{
       arch: {label: job.arch, value: job.arch},
       ctcSets: job.ctcSets,
       ctcPresets: job.ctcPresets,
+      ctcVersion: {label: job.ctcVersion, value: job.ctcVersion},
     } as any;
     job.saveEncodedFiles = true;
     this.setState({ job } as any);
@@ -126,6 +129,9 @@ export class SubmitJobFormComponent extends React.Component<{
       case "ctcPresets":
         if (job.ctcPresets) return "success";
         break;
+      case "ctcVersion":
+        if (job.ctcVersion) return "success";
+        break;
     }
     return "error";
   }
@@ -134,6 +140,9 @@ export class SubmitJobFormComponent extends React.Component<{
   }
   onCtcPresetsSelection(ctcPresets: Option) {
     this.setState({ ctcPresets } as any, () => { });
+  }
+  onCtcVersionSelection(ctcVersion: Option) {
+    this.setState({ ctcVersion } as any, () => { });
   }
   onInputChange(key: string, e: any) {
     let job = this.state.job;
@@ -216,6 +225,9 @@ export class SubmitJobFormComponent extends React.Component<{
         job.codec = job.ctcPresets[0];
       }
     }
+    // AOM: Add CTC version for each jobs
+    job.ctcVersion = this.state.ctcVersion.value;
+
     this.props.onCreate(job);
   }
   onCancel() {
@@ -259,6 +271,7 @@ export class SubmitJobFormComponent extends React.Component<{
     // CTC: Create a user-friendly CTC set list.
     const ctcOptions = [{ value: 'aomctc-a1-4k', label: 'A1' }, { value: 'aomctc-a2-2k', label: 'A2' }, { value: 'aomctc-a3-720p', label: 'A3' }, { value: 'aomctc-a4-360p', label: 'A4' }, { value: 'aomctc-a5-270p', label: 'A5' }, { value: 'aomctc-b1-syn', label: 'B1' }, { value: 'aomctc-b2-syn', label: 'B2' }, { value: 'aomctc-f1-hires', label: 'F1' }, { value: 'aomctc-f2-midres', label: 'F2' }, { value: 'aomctc-g1-hdr-4k', label: 'G1' }, { value: 'aomctc-g2-hdr-2k', label: 'G2' }, { value: 'aomctc-e-nonpristine', label: 'E' }, { value: 'aomctc-all', label: 'All' }, { value: 'aomctc-mandatory', label: 'Mandatory' }];
     const ctcPresetOptions = [{ value: 'av2-ra-st', label: 'RA' }, { value: 'av2-ra', label: 'RA (GOP parallel)' }, { value: 'av2-ai', label: 'AI' }, { value: 'av2-ld', label: 'LD' }, { value: 'av2-all', label: 'All' }];
+    const ctcVersionOptions = [{ value: '5.0', label: 'CTCv5.0' }, { value: '4.0', label: 'CTCv4.0' }];
 
     return <Form>
       <FormGroup validationState={this.getValidationState("id")}>
@@ -318,6 +331,11 @@ export class SubmitJobFormComponent extends React.Component<{
       <FormGroup validationState={this.getValidationState("ctcPresets")}>
         <ControlLabel>This will override the above preset (for AOM-CTC)</ControlLabel>
         <Select multi placeholder="CTC Presets" value={this.state.ctcPresets} options={ctcPresetOptions} onChange={this.onCtcPresetsSelection.bind(this)} />
+      </FormGroup>
+
+      <FormGroup validationState={this.getValidationState("ctcVersion")}>
+        <ControlLabel> Choose the AOM-CTC Version (Default: Current AVM Anchor)</ControlLabel>
+        <Select placeholder="CTC Version" value={this.state.ctcVersion} options={ctcVersionOptions} onChange={this.onCtcVersionSelection.bind(this)} />
       </FormGroup>
 
       <FormGroup>

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -369,6 +369,7 @@ export class Job {
   arch: string = "x86_64";
   ctcSets: string[] = [];
   ctcPresets: string[] = [];
+  ctcVersion: string = "5.0";
   submit_time: Date;
 
   progress: JobProgress = new JobProgress(0, 0);
@@ -574,6 +575,7 @@ export class Job {
     job.arch = json.arch || "x86_64";
     job.ctcSets = json.ctcSets || "";
     job.ctcPresets = json.ctcPresets || "";
+    job.ctcVersion = json.ctcVersion || "5.0";
     job.submit_time = json.submit_time || "";
 
     job.saveEncodedFiles = parseBoolean(json.save_encode);
@@ -844,6 +846,7 @@ export class AppStore {
       arch: job.arch,
       ctcSets: job.ctcSets,
       ctcPresets: job.ctcPresets,
+      ctcVersion: job.ctcVersion,
     });
   }
   cancelJob(job: Job) {

--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -575,7 +575,7 @@ export class Job {
     job.arch = json.arch || "x86_64";
     job.ctcSets = json.ctcSets || "";
     job.ctcPresets = json.ctcPresets || "";
-    job.ctcVersion = json.ctcVersion || "5.0";
+    job.ctcVersion = json.ctcVersion || "4.0";
     job.submit_time = json.submit_time || "";
 
     job.saveEncodedFiles = parseBoolean(json.save_encode);


### PR DESCRIPTION
This adds support to a CTC version toggle, 

<img width="316" alt="image" src="https://github.com/xiph/awcy/assets/10833993/c9b34113-ade8-4a2a-94e0-1b305234e04c">
<img width="293" alt="image" src="https://github.com/xiph/awcy/assets/10833993/9b88bb5d-b16d-4f47-a1f2-212c1a38fa9f">
<img width="291" alt="image" src="https://github.com/xiph/awcy/assets/10833993/e2654734-021d-4744-8244-fc364c974f5e">

Now the AWCY also supports CTCv4.0 and CTCv5.0 at the same time. 

This needs a subsequent backend change with https://github.com/xiph/rd_tool/pull/155

