### PR TITLE
www/JobSelector: Display only ReportedMetrics (libvmaf) only

### DIFF
--- a/www/src/components/JobSelector.tsx
+++ b/www/src/components/JobSelector.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { appStore, AppDispatcher, Jobs, Job, metricNames, AnalyzeFile } from "../stores/Stores";
+import { appStore, AppDispatcher, Jobs, Job, metricNames, AnalyzeFile, reportDisplayedMetrics } from "../stores/Stores";
 import { Option, arraysEqual } from "./Widgets";
 declare var require: any;
 let Select = require('react-select');
@@ -22,7 +22,7 @@ export class JobSelectorComponent extends React.Component<JobSelectorProps, {
     this.state = {
       video: null,
       metric: null,
-      metrics: metricNames.map(name => {
+      metrics: reportDisplayedMetrics.map(name => {
         return { value: name, label: name };
       }),
       videos: []


### PR DESCRIPTION
This is for the graphs

<img width="542" alt="image" src="https://github.com/xiph/awcy/assets/10833993/20527967-be0a-4960-98aa-57d13fcd2e15">

This will match the BDR table now, and reduce non-libvmaf metrics. 

