### PR TITLE
Add build support for rav1e and ARM (aarch64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,10 @@ RUN \
 	/tmp/rustup-init -y --no-modify-path --default-toolchain ${RUST_VERSION} && \
 	rm -vf /tmp/rustup-init
 
+# install cross-compile target (aarch64) for rust-based library
+RUN \
+	/usr/local/cargo/bin/rustup target add aarch64-unknown-linux-gnu
+
 # install node 18.x
 RUN \
 	NODE_VERSION=18.6.0 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ ENV \
 # install rust
 RUN \
 	ARCH=`uname -m` && \
-	RUST_VERSION=1.64.0 && \
+	RUST_VERSION=1.73.0 && \
 	curl -sSf --output /tmp/rustup-init https://static.rust-lang.org/rustup/archive/1.25.0/${ARCH}-unknown-linux-gnu/rustup-init && \
 	chmod +x /tmp/rustup-init && \
 	/tmp/rustup-init -y --no-modify-path --default-toolchain ${RUST_VERSION} && \

--- a/build_codec.sh
+++ b/build_codec.sh
@@ -119,7 +119,22 @@ case "${CODEC}" in
 
   rav1e)
     cd ${CODECS_SRC_DIR}/rav1e
-    cargo build --release ${BUILD_OPTIONS}
+    if [[ "${ARCH}" == "aarch64" ]]; then
+      ARCH_OPTIONS="--target aarch64-unknown-linux-gnu"
+      # Rust need aarch64 as environment variable or as a config inside cargo
+      # folder. So we chose latter for maintainability.
+      mkdir -p .cargo
+      echo -e "[target.aarch64-unknown-linux-gnu]\nlinker = \"aarch64-linux-gnu-gcc\"\nar = \"aarch64-linux-gnu-gcc\"" > .cargo/config
+      mkdir -p target/release
+    else
+      ARCH_OPTIONS=""
+    fi
+    cargo build --release ${ARCH_OPTIONS} ${BUILD_OPTIONS}
+    # Rust tries to create a target arch folder, it messes up lot more things,
+    # so easy is faking the path
+    if [[ "${ARCH}" == "aarch64" ]]; then
+      cp target/aarch64-unknown-linux-gnu/release/rav1e target/release/rav1e
+    fi
     ;;
 
   svt-av1*)


### PR DESCRIPTION
Few changes
+ Update Rust version to 1.73.0
+ Introduce aarch64-unknown-linux-gnu as toolchain
+ Update build instructions
