### PR TITLE
server: Optimise CSV Export and Frontend loading

### DIFF
--- a/www/src/stores/Stores.ts
+++ b/www/src/stores/Stores.ts
@@ -514,6 +514,18 @@ export class Job {
       // TODO: Fix -daala suffix.
       return this.reportUrl(name);
     }));
+
+    // For large sets of videos like more than 500, it is too slow to load and
+    // cache all the videos, so we can partially load only 20 videos in the
+    // frontend.
+    // For now, only do this for "elfuente-1080p-as" set from SIWG-CTC.
+    if (paths.length > 500) {
+      if (this.task == 'elfuente-1080p-as') {
+        paths = paths.slice(0, 20);
+        names = names.slice(0, 20);
+      }
+    }
+
     return this.loadFiles(paths).then(textArray => {
       function parse(text) {
         if (text === null) return null;


### PR DESCRIPTION
Previously we used execFile, it is fine as long as the csv generation is fast, when we start to do with 6k+ files, it is buggy + slow + impossible to get the reuslts (eg. 2.7MB CSV file). So, we can spawn a process, append the data to a varaible, wait till it is completed, and then spit it out.

PS: ExecFile is problematic when we read file-by-file for 6k+ files over network disk, (like main beta server)


This now matches how we do for XLSM export


Secondly, we now restrict the frontend to load only 20 videos instead of 5k/6k videos
