### PR TITLE
Do not allow to submit runs without COMMIT ID

### DIFF
--- a/create_test_branch.sh
+++ b/create_test_branch.sh
@@ -13,6 +13,13 @@ BRANCH=t-$(echo "${TESTNAME}" | sed "s/:/_/g")
 
 cd ${CODECS_SRC_DIR}/${CODEC}
 git reset --hard
+
+if [[ ${COMMIT} == "HEAD" ]];then
+    echo "Fetching latest changes from origin, and checking out to current HEAD"
+    git fetch origin
+    git checkout origin/HEAD
+fi
+
 if git checkout ${COMMIT}; then
     echo "Commit found, skipping fetch."
 else

--- a/www/src/components/SubmitJobForm.tsx
+++ b/www/src/components/SubmitJobForm.tsx
@@ -85,6 +85,9 @@ export class SubmitJobFormComponent extends React.Component<{
         if (commit.length === 41 && commit.charAt(0) === 'I') {
           return "error"; // Gerrit Change-ID format, not a git reference
         }
+        if (commit.length == 0) {
+          return "error";
+        }
         if (job.commit) return "success";
       case "codec":
         if (this.state.codec.value) return "success";
@@ -280,7 +283,7 @@ export class SubmitJobFormComponent extends React.Component<{
       </FormGroup>
 
       <FormGroup validationState={this.getValidationState("commit")}>
-        <FormControl type="text" placeholder="Git Commit Reference (Hash/Branch/Tag)"
+        <FormControl type="text" placeholder="Git Commit Reference (Hash/Branch/Tag/HEAD)"
           value={job.commit} onChange={this.onInputChange.bind(this, "commit")} />
       </FormGroup>
 


### PR DESCRIPTION
Now Commit field is mandatory,

<img width="400" alt="image" src="https://github.com/xiph/awcy/assets/10833993/1e86e266-5a84-4ff4-aa01-ce734fae5fcf">


We also introduce support to submit run with HEAD
<img width="471" alt="image" src="https://github.com/xiph/awcy/assets/10833993/edf96041-c873-4772-9b90-ad2623e34956">
